### PR TITLE
[0.14.1] Add feature to export sample in selection analysis

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Imports:
   ggrepel,
   jaspBase,
   jaspGraphs,
-  jfa (>= 0.5.0)
+  jfa (>= 0.5.0),
+  utils
 Remotes:
   jasp-stats/jaspBase,
   jasp-stats/jaspGraphs

--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -2304,6 +2304,29 @@
                                                                 "sampleIndicatorColumn"))
     jaspResults[["sampleIndicatorColumn"]]$setNominal(sampleIndicatorColumn)
   }
+  
+  # Export sample
+  if(options[["exportSample"]] && options[["file"]] != ""){
+    sampleExport <- data.frame(row = parentState[["rowNumber"]])
+    sampleExport <- cbind(sampleExport, count = parentState[["count"]])
+    sampleExport <- cbind(sampleExport, id = parentState[[.v(options[["recordNumberVariable"]])]])
+    colnames(sampleExport) <- c("Row number", decodeColNames(options[["sampleIndicatorColumn"]]), decodeColNames(options[["recordNumberVariable"]]))
+    if(options[["monetaryVariable"]] != ""){
+      sampleExport <- cbind(sampleExport, ist = parentState[[.v(options[["monetaryVariable"]])]])
+      colnames(sampleExport)[length(colnames(sampleExport))] <- decodeColNames(options[["monetaryVariable"]])
+    }
+    if(options[["rankingVariable"]] != ""){
+      sampleExport <- cbind(sampleExport, parentState[[.v(options[["rankingVariable"]])]])
+      colnames(sampleExport)[length(colnames(sampleExport))] <- decodeColNames(options[["rankingVariable"]])
+    }
+    if(length(unlist(options[["additionalVariables"]])) >= 1 && unlist(options[["additionalVariables"]]) != ""){
+      sampleExport <- cbind(sampleExport, parentState[[.v(unlist(options[["additionalVariables"]]))]])
+      colnames(sampleExport)[(length(colnames(sampleExport)) - length(unlist(options[["additionalVariables"]]))):length(colnames(sampleExport))] <- decodeColNames(unlist(options[["additionalVariables"]]))
+    }
+    sampleExport <- cbind(sampleExport, rep(NA, nrow(sampleExport)))
+    colnames(sampleExport)[length(colnames(sampleExport))] <- "Soll"
+    utils::write.csv2(x = sampleExport, file = options[["file"]], row.names = FALSE, na = "", dec = ",", sep = ";", quote = FALSE)
+  }
 }
 
 .jfa.selection.state <- function(options, dataset, prevState, parentContainer){

--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -2325,7 +2325,7 @@
     }
     sampleExport <- cbind(sampleExport, rep(NA, nrow(sampleExport)))
     colnames(sampleExport)[length(colnames(sampleExport))] <- "Soll"
-    utils::write.csv2(x = sampleExport, file = options[["file"]], row.names = FALSE, na = "", dec = ",", sep = ";", quote = FALSE)
+    utils::write.csv(x = sampleExport, file = options[["file"]], row.names = FALSE, na = "", quote = FALSE)
   }
 }
 

--- a/inst/qml/auditSelection.qml
+++ b/inst/qml/auditSelection.qml
@@ -369,20 +369,59 @@ Form
 		}
 	}
 
-	CheckBox 
-	{ 
-		id: 									addSampleIndicator  
-		name: 									"addSampleIndicator"
-		text: 									qsTr("Add selection counter to data")
-		enabled: 								recordNumberVariable.count > 0
+	GroupBox 
+	{
 
-		ComputedColumnField 
+		CheckBox 
 		{ 
-				id:								sampleIndicatorColumn
-				name: 							"sampleIndicatorColumn"
-				text: 							qsTr("Column name: ")
-				fieldWidth: 					120 * preferencesModel.uiScale
-				visible:    					addSampleIndicator.checked
+			id: 								addSampleIndicator  
+			name: 								"addSampleIndicator"
+			text: 								qsTr("Export sample to file")
+			enabled: 							recordNumberVariable.count > 0 & sampleSize.value > 0
+			onCheckedChanged:					if(!checked) exportSample.checked = false
+
+			ComputedColumnField 
+			{ 
+					id:							sampleIndicatorColumn
+					name: 						"sampleIndicatorColumn"
+					text: 						qsTr("Column name selection result: ")
+					placeholderText: 			qsTr("e.g. Count")
+					fieldWidth: 				120 * preferencesModel.uiScale
+					visible:					addSampleIndicator.checked
+			}
+
+				FileSelector
+				{
+					id:							file
+					name:						"file"
+					label:  					qsTr("Save as: ")
+					filter:						"*.csv"
+					save:						true
+					fieldWidth:					180 * preferencesModel.uiScale 
+					visible:					addSampleIndicator.checked
+				}
+		}
+
+		RowLayout
+		{
+			Button
+			{
+				id: 							downloadSampleSelection
+				Layout.leftMargin:				25 * preferencesModel.uiScale
+				text: 							exportSample.checked ? qsTr("<b>Synchronize: On</b>") : qsTr("<b>Synchronize: Off</b>")
+				control.color: 					exportSample.checked ? "#1E90FF" : jaspTheme.buttonColorDisabled
+				control.textColor: 				exportSample.checked ? "white" : "black"
+				implicitHeight:					20 * preferencesModel.uiScale
+				onClicked: 						exportSample.click()
+				enabled:						recordNumberVariable.count > 0 & sampleSize.value > 0 & addSampleIndicator.checked & sampleIndicatorColumn.value != "" & file.value != ""
+				visible:						addSampleIndicator.checked
+			}
+			CheckBox
+			{
+				id:								exportSample
+				name:							"exportSample"
+				visible:						false
+			}	
 		}
 	}
 
@@ -391,17 +430,6 @@ Form
 		Layout.preferredHeight: 				downloadReportSelection.height
 		Layout.fillWidth: 						true
 		Layout.columnSpan:						2
-
-		Button
-		{
-			id:									downloadDataSelection
-			anchors.right:	 					downloadReportSelection.left
-			anchors.rightMargin:				jaspTheme.generalAnchorMargin
-			text:								qsTr("<b>Export Data</b>")
-			enabled:							sampleSize.value > 0
-			onClicked: 							form.exportResults() // This should still be changed to data export
-			visible:							false // That is why this is false
-		}
 
 		Button
 		{


### PR DESCRIPTION
This pr adds the possibility to export the selected sample in the selection analysis to a `.csv` file. 

@AlexanderLyNL What do you think? Should we already merge this and include it into the code for 0.14.1? It impacts only the selection analysis and I tested it thoroughly. We still need have a second round of testing after the fixes from the audit analysis (and probably robma as it seems), so maybe these small changes can be tested as well? Or maybe leave it for after 0.14.1?

Edit: This will go into 0.14.1 since it is not very invasive code and we still have a second testing round.