### PR TITLE
Correlation test improvements (Two-sided to one-sided) + Benford's Law and Number bunching fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ License: GPL (>= 2)
 Encoding: UTF-8
 Imports:
   BAS,
+  bstats,
   ggplot2,
   ggrepel,
   jaspBase,

--- a/R/auditClassicalBenfordsLaw.R
+++ b/R/auditClassicalBenfordsLaw.R
@@ -485,14 +485,11 @@ jfaBenfordsLawTable <- function(dataset, options, benfordsLawContainer,
   
   state <- .jfaBenfordsLawState(dataset, options, benfordsLawContainer, ready)
   
-  approve <- state[["pvalue"]] >= (1 - options[["confidence"]])
+  rejectnull <- state[["pvalue"]] < (1 - options[["confidence"]])
+  conclusion <- if(rejectnull) gettext("is rejected") else gettext("is not rejected")
   
-  conclusion <- ifelse(approve, no = gettext("is rejected"), yes = gettext("is not rejected"))
-  
-  pvalue <- round(state[["pvalue"]], 3)
-  if(pvalue < 0.001)
-    pvalue <- "< .001"
-  pvalue <- ifelse(approve, no = paste0(pvalue, " < \u03B1"), yes = paste0(pvalue, " >= \u03B1"))
+  pvalue <- format.pval(state[["pvalue"]], eps = 0.001)
+  pvalue <- if(rejectnull) gettextf("%1$s < \u03B1", pvalue) else gettextf("%1$s >= \u03B1", pvalue)
   
   distribution <- base::switch(options[["distribution"]], "benford" = "Benford's law", "uniform" = "the uniform distribution")
   

--- a/R/auditClassicalNumberBunching.R
+++ b/R/auditClassicalNumberBunching.R
@@ -510,12 +510,9 @@ auditClassicalNumberBunching <- function(jaspResults, dataset, options, ...){
   state <- .jfaNumberBunchingState(dataset = NULL, options, jaspResults, ready)
   
   rejectnull <- state[["pvalueAvgFrequency"]] < (1 - options[["confidence"]])
-  
   conclusion <- if(rejectnull) gettext("is rejected") else gettext("is not rejected")
-  
-  pvalue <- round(state[["pvalueAvgFrequency"]], 3)
-  if(pvalue < 0.001)
-    pvalue <- "< .001"
+
+  pvalue <- format.pval(state[["pvalueAvgFrequency"]], eps = 0.001)
   pvalue <- if(rejectnull) gettextf("%1$s < \u03B1", pvalue) else gettextf("%1$s >= \u03B1", pvalue)
   
   conclusionText <- gettextf("The <i>p</i> value is %1$s and the null hypothesis that the data do not contain an unexpected amount of repeated values <b>%2$s</b>.", pvalue, conclusion)

--- a/R/auditClassicalNumberBunching.R
+++ b/R/auditClassicalNumberBunching.R
@@ -509,14 +509,14 @@ auditClassicalNumberBunching <- function(jaspResults, dataset, options, ...){
   
   state <- .jfaNumberBunchingState(dataset = NULL, options, jaspResults, ready)
   
-  approve <- state[["pvalueAvgFrequency"]] >= (1 - options[["confidence"]])
+  rejectnull <- state[["pvalueAvgFrequency"]] < (1 - options[["confidence"]])
   
-  conclusion <- if(approve) gettext("is rejected") else gettext("is not rejected")
+  conclusion <- if(rejectnull) gettext("is rejected") else gettext("is not rejected")
   
   pvalue <- round(state[["pvalueAvgFrequency"]], 3)
   if(pvalue < 0.001)
     pvalue <- "< .001"
-  pvalue <- if(approve) gettextf("%1$s < \u03B1", pvalue) else gettextf("%1$s >= \u03B1", pvalue)
+  pvalue <- if(rejectnull) gettextf("%1$s < \u03B1", pvalue) else gettextf("%1$s >= \u03B1", pvalue)
   
   conclusionText <- gettextf("The <i>p</i> value is %1$s and the null hypothesis that the data do not contain an unexpected amount of repeated values <b>%2$s</b>.", pvalue, conclusion)
   

--- a/R/auditCommonFunctionsBayesian.R
+++ b/R/auditCommonFunctionsBayesian.R
@@ -123,18 +123,6 @@
   return(results)
 }
 
-.jfaBayesianCorrelationCalculation <- function(r, n){
-  
-  # For the calculation of the Bayes factor for a correlation, we use the standard Bayesian test as described in:
-  # Wetzels, R., & Wagenmakers, E. J. (2012). A default Bayesian hypothesis test for correlations and partial correlations. Psychonomic bulletin & review, 19(6), 1057-1064.
-  
-  int <- function(r, n, g){
-    (1+g)^((n-2)/2)*(1+(1-r^2)*g)^(-(n-1)/2) * g^(-3/2)*exp(-n/(2*g))
-  }
-  bf10 <- sqrt((n/2))/gamma(1/2)*integrate(int, lower = 0, upper = Inf, r = r, n = n)$value
-  return(1 / bf10)
-}
-
 ################################################################################
 ################## Common functions specific to the planning stage #############
 ################################################################################
@@ -597,7 +585,7 @@
     if(options[["priorAndPosteriorPlotIndicateStatistics"]]){
       
       if(likelihood == "hypergeometric"){
-        confBound <- ceiling(confBound *N)
+        confBound <- ceiling(confBound * N)
         mle <- ceiling(mle * N)
       }
       
@@ -688,7 +676,7 @@
     
     if(options[["performanceMateriality"]]){                                               
       table$addColumnInfo(name = 'hMin', 	title = gettextf("Support %1$s", "H\u208B"), type = 'number')
-      table$addColumnInfo(name = 'hPlus', title = gettextf("Support %1$s", "H\u208A"), type = 'number')
+      table$addColumnInfo(name = 'hPlus', 	title = gettextf("Support %1$s", "H\u208A"), type = 'number')
       table$addColumnInfo(name = 'odds', 	title = gettextf("Ratio %1$s", "<sup>H\u208B</sup>&frasl;<sub>H\u208A</sub>"), type = 'number')
     }
     

--- a/inst/qml/auditClassicalBenfordsLaw.qml
+++ b/inst/qml/auditClassicalBenfordsLaw.qml
@@ -41,7 +41,7 @@ Form {
 			name: 						"values"
 			title: 						qsTr("Variable")
 			singleVariable:				true
-			allowedColumns:				["ordinal", "scale"]
+			allowedColumns:				["scale"]
 		}
 
 		DropDown 


### PR DESCRIPTION
+ Now use the same function as the Bayesian correlation analysis
+ Fix a bug in repeated values test where a p > alpha was said to reject the null hypothesis.
+ Only allow scale values in Benford's law.