### PR TITLE
Bug fixes and more

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
   ggrepel,
   jaspBase,
   jaspGraphs,
-  jfa (>= 0.6.1),
+  jfa (>= 0.6.2),
   utils
 Remotes:
   jasp-stats/jaspBase,

--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -680,7 +680,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
       "ir", "irCustom", "cr", "crCustom", "conf_level", "n_units", "materiality_type",
       "materiality_rel_val", "materiality_abs_val", "expected_type", "expected_rel_val",
       "expected_abs_val", "likelihood", "id", "values", "separateMisstatement",
-      "min_precision_rel_val", "min_precision_test", "materiality_test", "by", "prior_method",
+      "min_precision_rel_val", "min_precision_test", "materiality_test", "by", "max", "prior_method",
       "n", "x", "alpha", "beta", "display"
     ))
 
@@ -1470,7 +1470,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
         jfa::planning(
           materiality = materiality, min.precision = min_precision, expected = parentOptions[["expected_val"]],
           likelihood = options[["likelihood"]], N.units = if (options[["likelihood"]] == "hypergeometric") ceiling(N.units) else N.units, conf.level = confidence,
-          by = options[["by"]], max = 10000
+          by = options[["by"]], max = options[["max"]]
         )
       })
     } else {
@@ -1489,7 +1489,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
           jfa::planning(
             materiality = materiality, min.precision = min_precision, expected = parentOptions[["expected_val"]],
             likelihood = options[["likelihood"]], N.units = if (options[["likelihood"]] == "hypergeometric") ceiling(N.units) else N.units, conf.level = options[["conf_level"]],
-            prior = prior, by = options[["by"]], max = 10000
+            prior = prior, by = options[["by"]], max = options[["max"]]
           )
         }
       })
@@ -1497,7 +1497,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
 
     if (isTryError(result)) {
       if (jaspBase:::.extractErrorMessage(result) == "the sample size is lower than 'max'") {
-        parentContainer$setError(gettext("You cannot achieve your current sampling objectives with this population. The resulting sample size exceeds 10000. Adjust your sampling objectives or variables accordingly."))
+        parentContainer$setError(gettextf("You cannot achieve your current sampling objectives with this population. The resulting sample size exceeds the maximum of %1$s. Adjust the maximum option accordingly.", options[["max"]]))
         return()
       } else {
         parentContainer$setError(gettextf("An error occurred: %1$s", jaspBase:::.extractErrorMessage(result)))
@@ -1636,7 +1636,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
     message <- switch(options[["likelihood"]],
       "poisson" = gettextf("The minimum sample size is based on the Poisson distribution (%1$s = %2$s).", "\u03BB", round(parentState[["materiality"]] * parentState[["n"]], 4)),
       "binomial" =  gettextf("The minimum sample size is based on the binomial distribution (p = %1$s)", round(parentState[["materiality"]], 2)),
-      "hypergeometric" = gettextf("The minimum sample size is based on the hypergeometric distribution (N = %1$s, K = %2$s).", parentState[["N.units"]], ceiling(parentState[["N.units"]] * parentState[["materiality"]]))
+      "hypergeometric" = gettextf("The minimum sample size is based on the hypergeometric distribution (N = %1$s, K = %2$s).", format(parentState[["N.units"]], scientific = FALSE), format(ceiling(parentState[["N.units"]] * parentState[["materiality"]]), scientific = FALSE))
     )
   } else {
     message <- switch(options[["likelihood"]],
@@ -1652,7 +1652,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
       ),
       "hypergeometric" = gettextf(
         "The minimum sample size is based on the beta-binomial distribution (N = %1$s, %2$s = %3$s, %4$s = %5$s).",
-        parentState[["N.units"]],
+        format(parentState[["N.units"]], scientific = FALSE),
         "\u03B1", round(parentState[["prior"]][["description"]]$alpha, 3),
         "\u03B2", round(parentState[["prior"]][["description"]]$beta, 3)
       )
@@ -1843,7 +1843,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
           result <- jfa::planning(
             conf.level = confidence, materiality = materiality, min.precision = min_precision,
             expected = if (!options[["bayesian"]] && options[["ir"]] != "high" || options[["cr"]] != "high") 0 else parentOptions[["expected_val"]],
-            likelihood = likelihoods[i], N.units = if (likelihoods[i] == "hypergeometric") ceiling(N) else N, by = options[["by"]], max = 10000, prior = prior
+            likelihood = likelihoods[i], N.units = if (likelihoods[i] == "hypergeometric") ceiling(N) else N, by = options[["by"]], max = options[["max"]], prior = prior
           )
           n[i] <- result[["n"]]
           k[i] <- result[["x"]]
@@ -1885,7 +1885,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
         figure$plotObject <- plot
       } else {
         if (jaspBase:::.extractErrorMessage(leftPlotError) == "the sample size is lower than 'max'") {
-          figure$setError(gettext("You cannot achieve your current sampling objectives with this population. The resulting sample size exceeds 10000. Adjust your sampling objectives or variables accordingly."))
+          figure$setError(gettextf("You cannot achieve your current sampling objectives with this population. The resulting sample size exceeds the maximum of %1$s. Adjust the maximum option accordingly.", options[["max"]]))
         } else {
           figure$setError(gettextf("An error occurred in a call to the jfa package: %1$s", jaspBase:::.extractErrorMessage(leftPlotError)))
         }
@@ -1918,7 +1918,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
           result <- jfa::planning(
             conf.level = confidence, materiality = materiality, min.precision = min_precision,
             likelihood = options[["likelihood"]], expected = i - 1,
-            N.units = if (options[["likelihood"]] == "hypergeometric") ceiling(N) else N, by = options[["by"]], max = 10000, prior = prior
+            N.units = if (options[["likelihood"]] == "hypergeometric") ceiling(N) else N, by = options[["by"]], max = options[["max"]], prior = prior
           )
           n[i] <- result[["n"]]
         }
@@ -1952,7 +1952,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
         figure$plotObject <- plot
       } else {
         if (jaspBase:::.extractErrorMessage(rightPlotError) == "the sample size is lower than 'max'") {
-          figure$setError(gettext("You cannot achieve your current sampling objectives with this population. The resulting sample size exceeds 10000. Adjust your sampling objectives or variables accordingly."))
+          figure$setError(gettextf("You cannot achieve your current sampling objectives with this population. The resulting sample size exceeds the maximum of %1$s. Adjust the maximum option accordingly.", options[["max"]]))
         } else {
           figure$setError(gettextf("An error occurred in a call to the jfa package: %1$s", jaspBase:::.extractErrorMessage(rightPlotError)))
         }

--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -1161,7 +1161,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
 
       if (options[["materiality_test"]] && !options[["min_precision_test"]]) {
         message <- gettextf(
-          "The objective of this audit sampling procedure was to determine with %1$s confidence whether the misstatement in the population is lower than the specified performance materiality, in this case %2$s. For the current data, the %1$s upper bound on the misstatement is %3$s the performance materiality. \n\nThe conclusion on the basis of these results is that the misstatement in the population is %4$s than the performance materiality. %5$s",
+          "The objective of this audit sampling procedure was to determine with %1$s confidence whether the misstatement in the population is lower than the specified performance materiality, in this case %2$s. For the current data, the %1$s upper bound for the misstatement is %3$s the performance materiality. \n\nThe conclusion on the basis of these results is that the misstatement in the population is %4$s than the performance materiality. %5$s",
           planningOptions[["conf_level_label"]],
           planningOptions[["materiality_label"]],
           aboveBelowMateriality,
@@ -1179,7 +1179,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
         )
       } else if (options[["materiality_test"]] && options[["min_precision_test"]]) {
         message <- gettextf(
-          "The objective of this audit sampling procedure was to determine with %1$s confidence, and a minimum precision of %2$s, whether the misstatement in the population is lower than the specified performance materiality, in this case %3$s. For the current data, the %1$s upper bound on the misstatement is %4$s the performance materiality and the obtained precision is %5$s than the minimum precision. \n\nThe conclusion on the basis of these results is that, with a precision of %6$s, the misstatement in the population is %7$s than the performance materiality. %8$s",
+          "The objective of this audit sampling procedure was to determine with %1$s confidence, and a minimum precision of %2$s, whether the misstatement in the population is lower than the specified performance materiality, in this case %3$s. For the current data, the %1$s upper bound for the misstatement is %4$s the performance materiality and the obtained precision is %5$s than the minimum precision. \n\nThe conclusion on the basis of these results is that, with a precision of %6$s, the misstatement in the population is %7$s than the performance materiality. %8$s",
           planningOptions[["conf_level_label"]],
           paste0(options[["min_precision_rel_val"]] * 100, "%"),
           planningOptions[["materiality_label"]],
@@ -2578,7 +2578,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
 
     if (!options[["bayesian"]]) {
       additionalMessage <- gettextf(
-        "\n\nThese results imply that there is a %1$s probability that, when one would repeatedly sample from this population, the upper bound on \u03B8 is below %2$s with a precision of %3$s.",
+        "\n\nThese results imply that there is a %1$s probability that, when one would repeatedly sample from this population, the upper bound for \u03B8 is below %2$s with a precision of %3$s.",
         planningOptions[["conf_level_label"]],
         boundLabel,
         precisionLabel
@@ -2593,7 +2593,9 @@ gettextf <- function(fmt, ..., domain = NULL) {
     }
 
     message <- gettextf(
-      "The purpose of the evaluation stage is to infer the misstatement \u03B8 in the population on the basis of a sample.\n\nThe sample consisted of %1$s sampling units, of which a total of %2$s were misstated. The information from this sample %3$s results in a most likely error in the population of %4$s and an %5$s upper bound of %6$s. %7$s",
+      "The purpose of the evaluation stage is to infer the misstatement \u03B8 in the population on the basis of a sample.\n\nThe population consisted of %1$s items and %2$s units. The sample consisted of %3$s sampling units, of which a total of %4$s were misstated. The information from this sample %5$s results in a most likely error in the population of %6$s and an %7$s upper bound of %8$s. %9$s",
+      if (planningOptions[["N.items"]] == 0) "..." else format(planningOptions[["N.items"]], scientific = FALSE),
+      if (planningOptions[["N.units"]] == 0.01) "..." else format(planningOptions[["N.units"]], scientific = FALSE),
       sampleSizeMessage,
       errors,
       if (options[["bayesian"]]) "combined with the information in the prior distribution " else "",

--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -515,14 +515,14 @@ gettextf <- function(fmt, ..., domain = NULL) {
     out <- list()
 
     if (!is.null(id)) {
-      dataset <- .readDataSetToEnd(columns.as.factor = id, exclude.na.listwise = id)
+      dataset <- .readDataSetToEnd(columns = id, exclude.na.listwise = id)
       dataset[[id]] <- as.character(dataset[[id]])
 
       out[["N.items"]] <- nrow(dataset)
       out[["N.items.unique"]] <- length(unique(dataset[[id]]))
 
       if (!is.null(values)) {
-        dataset <- .readDataSetToEnd(columns.as.numeric = values, columns.as.factor = id, exclude.na.listwise = c(values, id))
+        dataset <- .readDataSetToEnd(columns.as.numeric = values, columns = id, exclude.na.listwise = c(values, id))
         dataset[[id]] <- as.character(dataset[[id]])
 
         data_values <- dataset[[values]]
@@ -570,7 +570,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
   }
 
   if (!is.null(variables)) {
-    dataset <- .readDataSetToEnd(columns.as.factor = id, columns.as.numeric = variables[which(variables != id)], exclude.na.listwise = variables)
+    dataset <- .readDataSetToEnd(columns = id, columns.as.numeric = variables[which(variables != id)], exclude.na.listwise = variables)
     dataset[[id]] <- as.character(dataset[[id]])
     if (stage == "evaluation" && !is.null(times) && !is.null(id) && !is.null(values.audit)) { # Apply sample filter only when required variables are given
       dataset <- subset(dataset, dataset[[times]] > 0)

--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -989,72 +989,78 @@ gettextf <- function(fmt, ..., domain = NULL) {
         }
 
         introMessage <- gettext("The purpose of the planning stage is to find a minimum sample size so that, given a certain number of expected misstatements, the sample provides sufficient information to achieve the specified sampling objectives.\n\n")
+        if (options[["separateMisstatement"]] && options[["expected_type"]] == "expected_all") {
+          mleMessage <- gettext("No assumptions are made about the most likely expected error in the sample.")
+        } else {
+          mleMessage <- gettextf("The most likely expected error in the sample is expected to be %1$s.", stageOptions[["expected_label"]])
+        }
+        finalx <- if (options[["separateMisstatement"]] && options[["expected_type"]] == "expected_all") stageState[["n"]] else stageState[["x"]]
         if (options[["prior_method"]] == "default" || options[["prior_method"]] == "strict") {
           stageContainer[["paragraph"]] <- createJaspHtml(gettextf(
-            "%1$sThe most likely expected error in the sample is expected to be %2$s. The minimum sample size that is required for %3$s, assuming the sample contains %4$s full errors, is %5$s. This sample size is based on the %6$s distribution, the a priori assumption that every value of the misstatement is equally likely, and the given expected errors.\n\nConsequently, if the intended sample is evaluated and the sum of (proportional) misstatements in the audited items is lower than (or equal to) %7$s, %8$s. %9$s",
+            "%1$s%2$s The minimum sample size that is required for %3$s, assuming the sample contains %4$s errors, is %5$s. This sample size is based on the %6$s distribution, the a priori assumption that every value of the misstatement is equally likely, and the given expected errors.\n\nConsequently, if the intended sample is evaluated and the sum of (proportional) misstatements in the audited items is lower than (or equal to) %7$s, %8$s. %9$s",
             introMessage,
-            stageOptions[["expected_label"]],
+            mleMessage,
             samplingObjectivesMessage,
-            stageState[["x"]],
+            finalx,
             stageState[["n"]],
             distribution,
-            stageState[["x"]],
+            finalx,
             samplingObjectivesMessage2,
             separateMisstatementMessage
           ), "p")
         } else if (options[["prior_method"]] == "arm") {
           stageContainer[["paragraph"]] <- createJaspHtml(gettextf(
-            "%1$sThe most likely expected error in the sample is expected to be %2$s. The minimum sample size that is required for %3$s, assuming the sample contains %4$s full errors, is %5$s. This sample size is based on the %6$s distribution, the a priori assessments of inherent risk (<i>%7$s</i>) and control risk (<i>%8$s</i>) from the Audit Risk Model, and the given expected errors.\n\nConsequently, if the intended sample is evaluated and the sum of (proportional) misstatements in the audited items is lower than (or equal to) %9$s, %10$s. %11$s",
+            "%1$s%2$s The minimum sample size that is required for %3$s, assuming the sample contains %4$s errors, is %5$s. This sample size is based on the %6$s distribution, the a priori assessments of inherent risk (<i>%7$s</i>) and control risk (<i>%8$s</i>) from the Audit Risk Model, and the given expected errors.\n\nConsequently, if the intended sample is evaluated and the sum of (proportional) misstatements in the audited items is lower than (or equal to) %9$s, %10$s. %11$s",
             introMessage,
-            stageOptions[["expected_label"]],
+            mleMessage,
             samplingObjectivesMessage,
-            stageState[["x"]],
+            finalx,
             stageState[["n"]],
             distribution,
             options[["ir"]],
             options[["cr"]],
-            stageState[["x"]],
+            finalx,
             samplingObjectivesMessage2,
             separateMisstatementMessage
           ), "p")
         } else if (options[["prior_method"]] == "impartial") {
           stageContainer[["paragraph"]] <- createJaspHtml(gettextf(
-            "%1$sThe most likely expected error in the sample is expected to be %2$s. The minimum sample size that is required for %3$s, assuming the sample contains %4$s full errors, is %5$s. This sample size is based on the %6$s distribution, the a priori assumption that tolerable misstatement is equally likely to occur as intolerable misstatement, and the given expected errors.\n\nConsequently, if the intended sample is evaluated and the sum of (proportional) misstatements in the audited items is lower than (or equal to) %7$s, %8$s. %9$s",
+            "%1$s%2$s The minimum sample size that is required for %3$s, assuming the sample contains %4$s errors, is %5$s. This sample size is based on the %6$s distribution, the a priori assumption that tolerable misstatement is equally likely to occur as intolerable misstatement, and the given expected errors.\n\nConsequently, if the intended sample is evaluated and the sum of (proportional) misstatements in the audited items is lower than (or equal to) %7$s, %8$s. %9$s",
             introMessage,
-            stageOptions[["expected_label"]],
+            mleMessage,
             samplingObjectivesMessage,
-            stageState[["x"]],
+            finalx,
             stageState[["n"]],
             distribution,
-            stageState[["x"]],
+            finalx,
             samplingObjectivesMessage2,
             separateMisstatementMessage
           ), "p")
         } else if (options[["prior_method"]] == "sample") {
           stageContainer[["paragraph"]] <- createJaspHtml(gettextf(
-            "%1$sThe most likely expected error in the sample is expected to be %2$s. The minimum sample size that is required for %3$s, assuming the sample contains %4$s full errors, is %5$s. This sample size is based on the %6$s distribution, the a priori assumption that an earlier sample of %7$s transactions containing %8$s errors is seen, and the given expected errors.\n\nConsequently, if the intended sample is evaluated and the sum of (proportional) misstatements in the audited items is lower than (or equal to) %9$s, %10$s. %11$s",
+            "%1$s%2$s The minimum sample size that is required for %3$s, assuming the sample contains %4$s errors, is %5$s. This sample size is based on the %6$s distribution, the a priori assumption that an earlier sample of %7$s transactions containing %8$s errors is seen, and the given expected errors.\n\nConsequently, if the intended sample is evaluated and the sum of (proportional) misstatements in the audited items is lower than (or equal to) %9$s, %10$s. %11$s",
             introMessage,
-            stageOptions[["expected_label"]],
+            mleMessage,
             samplingObjectivesMessage,
-            stageState[["x"]],
+            finalx,
             stageState[["n"]],
             distribution,
             options[["n"]],
             options[["x"]],
-            stageState[["x"]],
+            finalx,
             samplingObjectivesMessage2,
             separateMisstatementMessage
           ), "p")
         } else if (options[["prior_method"]] == "param") {
           stageContainer[["paragraph"]] <- createJaspHtml(gettextf(
-            "%1$sThe most likely expected error in the sample is expected to be %2$s. The minimum sample size that is required for %3$s, assuming the sample contains %4$s full errors, is %5$s. This sample size is based on the %6$s distribution, the manually specified prior distribution, and the given expected errors.\n\nConsequently, if the intended sample is evaluated and the sum of (proportional) misstatements in the audited items is lower than (or equal to) %7$s, %8$s. %9$s",
+            "%1$s%2$s The minimum sample size that is required for %3$s, assuming the sample contains %4$s errors, is %5$s. This sample size is based on the %6$s distribution, the manually specified prior distribution, and the given expected errors.\n\nConsequently, if the intended sample is evaluated and the sum of (proportional) misstatements in the audited items is lower than (or equal to) %7$s, %8$s. %9$s",
             introMessage,
-            stageOptions[["expected_label"]],
+            mleMessage,
             samplingObjectivesMessage,
-            stageState[["x"]],
+            finalx,
             stageState[["n"]],
             distribution,
-            stageState[["x"]],
+            finalx,
             samplingObjectivesMessage2,
             separateMisstatementMessage
           ), "p")
@@ -2310,7 +2316,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
   .jfaTableNumberUpdate(jaspResults)
 
   if (is.null(parentContainer[["tableSample"]])) {
-    title <- gettextf("<b>Table %1$i.</b> Raw Sample", jaspResults[["tabNumber"]]$object)
+    title <- gettextf("<b>Table %1$i.</b> Selected Items", jaspResults[["tabNumber"]]$object)
     table <- createJaspTable(title)
     table$position <- positionInContainer
     table$dependOn(options = c("tableBookDist", "tableDescriptives", "tableSample", "samplingChecked", "evaluationChecked"))
@@ -3353,7 +3359,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
 
     # We choose a pseudo-random seed to get the impression of a random starting point
     # It is unlikely that two populations or users have the same seed
-    set.seed(-0.4083114 + options[["by"]] + parentOptions[["N.units"]])
+    set.seed(-0.4083114 + options[["by"]] + parentOptions[["N.units"]]) # -0.4083114 for backwards compatibility
 
     intervalStartingPoint <- sample(1:(interval - 1), size = 1)
     intervalSelection <- intervalStartingPoint + 0:(n - 1) * interval

--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -3353,7 +3353,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
 
     # We choose a pseudo-random seed to get the impression of a random starting point
     # It is unlikely that two populations or users have the same seed
-    set.seed(rnorm(1) + options[["by"]] + parentOptions[["N.units"]])
+    set.seed(-0.4083114 + options[["by"]] + parentOptions[["N.units"]])
 
     intervalStartingPoint <- sample(1:(interval - 1), size = 1)
     intervalSelection <- intervalStartingPoint + 0:(n - 1) * interval

--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -1466,10 +1466,9 @@ gettextf <- function(fmt, ..., domain = NULL) {
     }
 
     if (!options[["bayesian"]]) {
-      expected <- if (options[["ir"]] != "high" || options[["cr"]] != "high") 0 else parentOptions[["expected_val"]]
       result <- try({
         jfa::planning(
-          materiality = materiality, min.precision = min_precision, expected = expected,
+          materiality = materiality, min.precision = min_precision, expected = parentOptions[["expected_val"]],
           likelihood = options[["likelihood"]], N.units = if (options[["likelihood"]] == "hypergeometric") ceiling(N.units) else N.units, conf.level = confidence,
           by = options[["by"]], max = 10000
         )

--- a/R/auditCommonFunctionsBayesian.R
+++ b/R/auditCommonFunctionsBayesian.R
@@ -311,7 +311,7 @@
       "<b>Figure %1$i.</b> The %2$s predictive distribution is %3$s and displays the predictions of the %2$s distribution for %4$s <i>n</i> = %5$s.",
       jaspResults[["figNumber"]]$object,
       if (stage == "planning") gettext("prior") else gettext("posterior"),
-      if (parentState[["posterior"]]$likelihood == "poisson") gettextf("negative binomial(r = %1$s, p = %2$s)", round(object[["predictive"]][["description"]]$r, 3), round(object[["predictive"]][["description"]]$p, 3)) else gettextf("beta-binomial(N = %1$s, \u03B1 = %2$s, \u03B2 = %3$s)", size, round(object[["predictive"]][["description"]]$alpha, 3), round(object[["predictive"]][["description"]]$beta, 3)),
+      if (parentState[["posterior"]]$likelihood == "poisson") gettext("negative binomial") else gettext("beta-binomial"),
       if (stage == "planning") gettext("the intended sample of") else gettext("the remaining population of"),
       size
     ), "p")

--- a/R/auditCommonFunctionsBayesian.R
+++ b/R/auditCommonFunctionsBayesian.R
@@ -202,7 +202,7 @@
       plot <- plot + ggplot2::geom_errorbarh(data = errorDat, ggplot2::aes(y = y, xmin = xmin, xmax = xmax), inherit.aes = FALSE, size = 1, height = (yBreaks[length(yBreaks)] - (yMax)) / 3 * 2)
       text_right <- jaspGraphs:::draw2Lines(c(label_ub, label_mode), x = 1, align = "right")
 
-      if (options[["materiality_test"]]) {
+      if (options[["materiality_test"]] && !is.na(parentState[["posterior"]]$hypotheses$bf.h1)) {
         lab1 <- paste0("BF\u208A\u208B = ", formatC(parentState[["posterior"]]$hypotheses$bf.h0, 3, format = "f"))
         lab2 <- paste0("BF\u208B\u208A = ", formatC(parentState[["posterior"]]$hypotheses$bf.h1, 3, format = "f"))
         text_left <- jaspGraphs:::draw2Lines(c(lab1, lab2), x = 0.65, align = "center")

--- a/inst/help/auditbayesianevaluation.md
+++ b/inst/help/auditbayesianevaluation.md
@@ -85,7 +85,7 @@ The expected errors are the tolerable errors that can be found in the sample whi
 #### Format Tables
 - Numbers: Display table output as numbers.
 - Percentages: Display table output as percentages.
-- Extrapolated amounts: Display table output as monetary values.
+- Monetary values: Display table output as monetary values.
 
 #### Assume Homogeneous Taints
 Clicking this box will allow you to separate the known and the unknown misstatement in the population to be more efficient. Note that this requires the assumption that the taints in the sample are representative of the taints in the unseen part of the population.

--- a/inst/help/auditbayesianevaluation.md
+++ b/inst/help/auditbayesianevaluation.md
@@ -138,7 +138,7 @@ Clicking this box will allow you to separate the known and the unknown misstatem
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
+- Derks, K. (2022). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 - Dyer, D., & Pierce, R. L. (1993). On the choice of the prior distribution in hypergeometric sampling. <i>Communications in Statistics-Theory and Methods</i>, 22(8), 2125-2146.
 - Stewart, T. R. (2013). A Bayesian audit assurance model with application to the component materiality problem in group audits (Doctoral dissertation).
 - de Swart, J., Wille, J., & Majoor, B. (2013). Het 'Push Left'-Principe als Motor van Data Analytics in de Accountantscontrole [The 'Push-Left'-Principle as a Driver of Data Analytics in Financial Audit]. <i>Maandblad voor Accountancy en Bedrijfseconomie</i>, 87, 425-432.

--- a/inst/help/auditbayesianevaluation.md
+++ b/inst/help/auditbayesianevaluation.md
@@ -138,7 +138,7 @@ Clicking this box will allow you to separate the known and the unknown misstatem
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.1.
+- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 - Dyer, D., & Pierce, R. L. (1993). On the choice of the prior distribution in hypergeometric sampling. <i>Communications in Statistics-Theory and Methods</i>, 22(8), 2125-2146.
 - Stewart, T. R. (2013). A Bayesian audit assurance model with application to the component materiality problem in group audits (Doctoral dissertation).
 - de Swart, J., Wille, J., & Majoor, B. (2013). Het 'Push Left'-Principe als Motor van Data Analytics in de Accountantscontrole [The 'Push-Left'-Principle as a Driver of Data Analytics in Financial Audit]. <i>Maandblad voor Accountancy en Bedrijfseconomie</i>, 87, 425-432.

--- a/inst/help/auditbayesianevaluation.md
+++ b/inst/help/auditbayesianevaluation.md
@@ -138,7 +138,7 @@ Clicking this box will allow you to separate the known and the unknown misstatem
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.0.
+- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.1.
 - Dyer, D., & Pierce, R. L. (1993). On the choice of the prior distribution in hypergeometric sampling. <i>Communications in Statistics-Theory and Methods</i>, 22(8), 2125-2146.
 - Stewart, T. R. (2013). A Bayesian audit assurance model with application to the component materiality problem in group audits (Doctoral dissertation).
 - de Swart, J., Wille, J., & Majoor, B. (2013). Het 'Push Left'-Principe als Motor van Data Analytics in de Accountantscontrole [The 'Push-Left'-Principle as a Driver of Data Analytics in Financial Audit]. <i>Maandblad voor Accountancy en Bedrijfseconomie</i>, 87, 425-432.

--- a/inst/help/auditbayesianevaluation_nl.md
+++ b/inst/help/auditbayesianevaluation_nl.md
@@ -138,7 +138,7 @@ Als u op dit vakje klikt, kunt u de bekende en onbekende afwijking in de populat
 ### Referenties
 ---
 - AICPA (2017). <i>Auditgids: controlesteekproeven</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesiaanse en klassieke auditsteekproeven. R-pakket versie 0.6.0.
+- Derks, K. (2022). jfa: Bayesiaanse en klassieke auditsteekproeven. R-pakket versie 0.6.2.
 - Dyer, D., & Pierce, R.L. (1993). Over de keuze van de voorafgaande verdeling bij hypergeometrische steekproeven. <i>Communicatie in statistiek-theorie en methoden</i>, 22(8), 2125-2146.
 - Stewart, TR (2013). Een Bayesiaans audit assurance-model met toepassing op het component materialiteitsprobleem bij groepsaudits (proefschrift).
 - de Swart, J., Wille, J., & Majoor, B. (2013). Het 'Push-Left'-Principe als Motor van Data Analytics in de Accountantcontrole [Het 'Push-Left'-Principe als aanjager van Data Analytics in Financial Audit]. <i>Maandblad voor Accountancy en Bedrijfseconomie</i>, 87, 425-432.

--- a/inst/help/auditbayesianplanning.md
+++ b/inst/help/auditbayesianplanning.md
@@ -98,7 +98,7 @@ The expected errors are the tolerable errors that can be found in the sample whi
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.1.
+- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 - Dyer, D., & Pierce, R. L. (1993). On the choice of the prior distribution in hypergeometric sampling. <i>Communications in Statistics-Theory and Methods</i>, 22(8), 2125-2146.
 - Stewart, T. R. (2013). A Bayesian audit assurance model with application to the component materiality problem in group audits (Doctoral dissertation).
 - de Swart, J., Wille, J., & Majoor, B. (2013). Het 'Push Left'-Principe als Motor van Data Analytics in de Accountantscontrole [The 'Push-Left'-Principle as a Driver of Data Analytics in Financial Audit]. <i>Maandblad voor Accountancy en Bedrijfseconomie</i>, 87, 425-432.

--- a/inst/help/auditbayesianplanning.md
+++ b/inst/help/auditbayesianplanning.md
@@ -29,9 +29,9 @@ The expected errors are the tolerable errors that can be found in the sample whi
 - Absolute: Enter your expected errors as the sum of (proportional) errors.
 
 #### Probability Distribution
-- Gamma: The gamma distribution accompanies the Poisson likelihood. The Poisson likelihood assumes an infinite population size and is therefore generally used when the population size is large. It is a likelihood that models the rate of misstatement (*\u03B8*) as a function of the observed sample size (*n*) and the sum of the proportional errors found (*t*). Because the gamma distribution accommodates partial errors it is generally used when you are planning a monetary unit sample (Stewart, 2013).
-- Beta: The beta distribution accompanies the binomial likelihood. The binomial likelihood assumes an infinite population size and is therefore generally used when the population size is large. It is a likelihood that models the rate of misstatement (*\u03B8*) as a function of the observed number of errors (*k*) and the number of correct transactions (*n - k*). Because the binomial distribution strictly does not accommodate partial errors, it is generally used when you are not planning a monetary unit sample. However, the beta distribution does accommodate partial errors, and may also be used for monetary unit sampling (de Swart, Wille & Majoor, 2013).
 - Beta-binomial: The beta-binomial distribution accompanies the hypergeometric likelihood (Dyer & Pierce, 1993). The hypergeometric likelihood assumes a finite population size and is therefore generally used when the population size is small. It is a likelihood that models the number of errors (*K*) in the population as a function of the population size (*N*), the number of observed found errors (*k*) and the number of correct transactions (*n*).
+- Beta: The beta distribution accompanies the binomial likelihood. The binomial likelihood assumes an infinite population size and is therefore generally used when the population size is large. It is a likelihood that models the rate of misstatement (*\u03B8*) as a function of the observed number of errors (*k*) and the number of correct transactions (*n - k*). Because the binomial distribution strictly does not accommodate partial errors, it is generally used when you are not planning a monetary unit sample. However, the beta distribution does accommodate partial errors, and may also be used for monetary unit sampling (de Swart, Wille & Majoor, 2013).
+- Gamma: The gamma distribution accompanies the Poisson likelihood. The Poisson likelihood assumes an infinite population size and is therefore generally used when the population size is large. It is a likelihood that models the rate of misstatement (*\u03B8*) as a function of the observed sample size (*n*) and the sum of the proportional errors found (*t*). Because the gamma distribution accommodates partial errors it is generally used when you are planning a monetary unit sample (Stewart, 2013).
 
 #### Display
 - Explanatory Text: When checked, enables explanatory text in the analysis to help interpret the procedure and the statistical results.
@@ -97,7 +97,7 @@ The increment alows you to limit the possible sample sizes to a multiple of its 
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.0.
+- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.1.
 - Dyer, D., & Pierce, R. L. (1993). On the choice of the prior distribution in hypergeometric sampling. <i>Communications in Statistics-Theory and Methods</i>, 22(8), 2125-2146.
 - Stewart, T. R. (2013). A Bayesian audit assurance model with application to the component materiality problem in group audits (Doctoral dissertation).
 - de Swart, J., Wille, J., & Majoor, B. (2013). Het 'Push Left'-Principe als Motor van Data Analytics in de Accountantscontrole [The 'Push-Left'-Principle as a Driver of Data Analytics in Financial Audit]. <i>Maandblad voor Accountancy en Bedrijfseconomie</i>, 87, 425-432.

--- a/inst/help/auditbayesianplanning.md
+++ b/inst/help/auditbayesianplanning.md
@@ -61,8 +61,9 @@ The expected errors are the tolerable errors that can be found in the sample whi
 - Numbers: Display table output as numbers.
 - Percentages: Display table output as percentages.
 
-#### Increment
-The increment alows you to limit the possible sample sizes to a multiple of its value. For example, an increment of 5 allows only sample sizes of 5, 10, 15, 20, 25, etc.
+#### Iterations
+- Increment: The increment alows you to limit the possible sample sizes to a multiple of its value. For example, an increment of 5 allows only sample sizes of 5, 10, 15, 20, 25, etc.
+- Maximum: The maximum allows you to limit the sample size with a maximum.
 
 ### Output
 ---

--- a/inst/help/auditbayesianplanning.md
+++ b/inst/help/auditbayesianplanning.md
@@ -98,7 +98,7 @@ The expected errors are the tolerable errors that can be found in the sample whi
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
+- Derks, K. (2022). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 - Dyer, D., & Pierce, R. L. (1993). On the choice of the prior distribution in hypergeometric sampling. <i>Communications in Statistics-Theory and Methods</i>, 22(8), 2125-2146.
 - Stewart, T. R. (2013). A Bayesian audit assurance model with application to the component materiality problem in group audits (Doctoral dissertation).
 - de Swart, J., Wille, J., & Majoor, B. (2013). Het 'Push Left'-Principe als Motor van Data Analytics in de Accountantscontrole [The 'Push-Left'-Principle as a Driver of Data Analytics in Financial Audit]. <i>Maandblad voor Accountancy en Bedrijfseconomie</i>, 87, 425-432.

--- a/inst/help/auditbayesianplanning_nl.md
+++ b/inst/help/auditbayesianplanning_nl.md
@@ -97,7 +97,7 @@ Met de stapgrootte kunt u de mogelijke steekproefomvang beperken tot een veelvou
 ### Referenties
 ---
 - AICPA (2017). <i>Auditgids: controlesteekproeven</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesiaanse en klassieke auditsteekproeven. R-pakket versie 0.6.0.
+- Derks, K. (2022). jfa: Bayesiaanse en klassieke auditsteekproeven. R-pakket versie 0.6.2.
 - Dyer, D., & Pierce, R.L. (1993). Over de keuze van de voorafgaande verdeling bij hypergeometrische steekproeven. <i>Communicatie in statistiek-theorie en methoden</i>, 22(8), 2125-2146.
 - Stewart, TR (2013). Een Bayesiaans audit assurance-model met toepassing op het component materialiteitsprobleem bij groepsaudits (proefschrift).
 - de Swart, J., Wille, J., & Majoor, B. (2013). Het 'Push-Left'-Principe als Motor van Data Analytics in de Accountantcontrole [Het 'Push-Left'-Principe als aanjager van Data Analytics in Financial Audit]. <i>Maandblad voor Accountancy en Bedrijfseconomie</i>, 87, 425-432.

--- a/inst/help/auditbayesianworkflow.md
+++ b/inst/help/auditbayesianworkflow.md
@@ -266,7 +266,7 @@ See *Probability Distribution*.
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
+- Derks, K. (2022). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 - Dyer, D., & Pierce, R. L. (1993). On the choice of the prior distribution in hypergeometric sampling. <i>Communications in Statistics-Theory and Methods</i>, 22(8), 2125-2146.
 - Stewart, T. R. (2013). A Bayesian audit assurance model with application to the component materiality problem in group audits (Doctoral dissertation).
 - de Swart, J., Wille, J., & Majoor, B. (2013). Het 'Push Left'-Principe als Motor van Data Analytics in de Accountantscontrole [The 'Push-Left'-Principle as a Driver of Data Analytics in Financial Audit]. <i>Maandblad voor Accountancy en Bedrijfseconomie</i>, 87, 425-432.

--- a/inst/help/auditbayesianworkflow.md
+++ b/inst/help/auditbayesianworkflow.md
@@ -150,7 +150,7 @@ Randomizes the items in the population before selection is performed.
 
 #### Tables
 - Descriptive statistics: Produces a table containing descriptive information about numerical variables in the selection. Statistics that are included are the mean, the median, the standard deviation, the variance, the minimum, the maximum, and the range.
-- Display sample: Produces a table containing the selected transactions along with any additional observations provided in the additional variables field.
+- Selected items: Produces a table containing the selected transactions along with any additional observations provided in the additional variables field.
 
 ### Output - Selection
 ---
@@ -179,7 +179,7 @@ Randomizes the items in the population before selection is performed.
 - Minimum: Minimum of the data points.
 - Maximum: Maximum of the data points.
 
-#### Display Sample
+#### Selected Items
 - Row: The row number of the item.
 - Selected: The number of times (a unit in) the item is selected.
 

--- a/inst/help/auditbayesianworkflow.md
+++ b/inst/help/auditbayesianworkflow.md
@@ -38,9 +38,9 @@ The expected errors are the tolerable errors that can be found in the sample whi
 - Absolute: Enter your expected errors as the sum of (proportional) errors.
 
 #### Probability Distribution
-- Gamma: The gamma distribution accompanies the Poisson likelihood. The Poisson likelihood assumes an infinite population size and is therefore generally used when the population size is large. It is a likelihood that models the rate of misstatement (*\u03B8*) as a function of the observed sample size (*n*) and the sum of the proportional errors found (*t*). Because the gamma distribution accommodates partial errors it is generally used when you are planning a monetary unit sample (Stewart, 2013).
-- Beta: The beta distribution accompanies the binomial likelihood. The binomial likelihood assumes an infinite population size and is therefore generally used when the population size is large. It is a likelihood that models the rate of misstatement (*\u03B8*) as a function of the observed number of errors (*k*) and the number of correct transactions (*n - k*). Because the binomial distribution strictly does not accommodate partial errors, it is generally used when you are not planning a monetary unit sample. However, the beta distribution does accommodate partial errors, and may also be used for monetary unit sampling (de Swart, Wille & Majoor, 2013).
 - Beta-binomial: The beta-binomial distribution accompanies the hypergeometric likelihood (Dyer & Pierce, 1993). The hypergeometric likelihood assumes a finite population size and is therefore generally used when the population size is small. It is a likelihood that models the number of errors (*K*) in the population as a function of the population size (*N*), the number of observed found errors (*k*) and the number of correct transactions (*n*).
+- Beta: The beta distribution accompanies the binomial likelihood. The binomial likelihood assumes an infinite population size and is therefore generally used when the population size is large. It is a likelihood that models the rate of misstatement (*\u03B8*) as a function of the observed number of errors (*k*) and the number of correct transactions (*n - k*). Because the binomial distribution strictly does not accommodate partial errors, it is generally used when you are not planning a monetary unit sample. However, the beta distribution does accommodate partial errors, and may also be used for monetary unit sampling (de Swart, Wille & Majoor, 2013).
+- Gamma: The gamma distribution accompanies the Poisson likelihood. The Poisson likelihood assumes an infinite population size and is therefore generally used when the population size is large. It is a likelihood that models the rate of misstatement (*\u03B8*) as a function of the observed sample size (*n*) and the sum of the proportional errors found (*t*). Because the gamma distribution accommodates partial errors it is generally used when you are planning a monetary unit sample (Stewart, 2013).
 
 #### Display
 - Explanatory Text: When checked, enables explanatory text in the analysis to help interpret the procedure and the statistical results.
@@ -265,7 +265,7 @@ See *Probability Distribution*.
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.0.
+- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.1.
 - Dyer, D., & Pierce, R. L. (1993). On the choice of the prior distribution in hypergeometric sampling. <i>Communications in Statistics-Theory and Methods</i>, 22(8), 2125-2146.
 - Stewart, T. R. (2013). A Bayesian audit assurance model with application to the component materiality problem in group audits (Doctoral dissertation).
 - de Swart, J., Wille, J., & Majoor, B. (2013). Het 'Push Left'-Principe als Motor van Data Analytics in de Accountantscontrole [The 'Push-Left'-Principle as a Driver of Data Analytics in Financial Audit]. <i>Maandblad voor Accountancy en Bedrijfseconomie</i>, 87, 425-432.

--- a/inst/help/auditbayesianworkflow.md
+++ b/inst/help/auditbayesianworkflow.md
@@ -77,8 +77,9 @@ The expected errors are the tolerable errors that can be found in the sample whi
 - Numbers: Display table output as numbers.
 - Percentages: Display table output as percentages.
 
-#### Increment
-The increment alows you to limit the possible sample sizes to a multiple of its value. For example, an increment of 5 allows only sample sizes of 5, 10, 15, 20, 25, etc.
+#### Iterations
+- Increment: The increment alows you to limit the possible sample sizes to a multiple of its value. For example, an increment of 5 allows only sample sizes of 5, 10, 15, 20, 25, etc.
+- Maximum: The maximum allows you to limit the sample size with a maximum.
 
 #### Assume Homogeneous Taints
 Clicking this box will allow you to separate the known and the unknown misstatement in the population to be more efficient. Note that this requires the assumption that the taints in the sample are representative of the taints in the unseen part of the population.

--- a/inst/help/auditbayesianworkflow.md
+++ b/inst/help/auditbayesianworkflow.md
@@ -266,7 +266,7 @@ See *Probability Distribution*.
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.1.
+- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 - Dyer, D., & Pierce, R. L. (1993). On the choice of the prior distribution in hypergeometric sampling. <i>Communications in Statistics-Theory and Methods</i>, 22(8), 2125-2146.
 - Stewart, T. R. (2013). A Bayesian audit assurance model with application to the component materiality problem in group audits (Doctoral dissertation).
 - de Swart, J., Wille, J., & Majoor, B. (2013). Het 'Push Left'-Principe als Motor van Data Analytics in de Accountantscontrole [The 'Push-Left'-Principle as a Driver of Data Analytics in Financial Audit]. <i>Maandblad voor Accountancy en Bedrijfseconomie</i>, 87, 425-432.

--- a/inst/help/auditbayesianworkflow.md
+++ b/inst/help/auditbayesianworkflow.md
@@ -144,12 +144,12 @@ The required number of sampling units that should be selected from the populatio
 - Random sampling: Performs random selection in which each sampling unit has an equal chance of being selected.
   - Seed: Selects the seed for the random number generator in order to reproduce results.
 
-#### Randomize Items
+#### Randomize Item Order
 Randomizes the items in the population before selection is performed.
 
 #### Tables
 - Descriptive statistics: Produces a table containing descriptive information about numerical variables in the selection. Statistics that are included are the mean, the median, the standard deviation, the variance, the minimum, the maximum, and the range.
-- Raw sample: Produces a table containing the selected transactions along with any additional observations provided in the additional variables field.
+- Display sample: Produces a table containing the selected transactions along with any additional observations provided in the additional variables field.
 
 ### Output - Selection
 ---
@@ -178,7 +178,7 @@ Randomizes the items in the population before selection is performed.
 - Minimum: Minimum of the data points.
 - Maximum: Maximum of the data points.
 
-#### Raw Sample
+#### Display Sample
 - Row: The row number of the item.
 - Selected: The number of times (a unit in) the item is selected.
 

--- a/inst/help/auditbayesianworkflow_nl.md
+++ b/inst/help/auditbayesianworkflow_nl.md
@@ -257,7 +257,7 @@ Zie *Kansverdeling*.
 ### Referenties
 ---
 - AICPA (2017). <i>Auditgids: controlesteekproeven</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesiaanse en klassieke auditsteekproeven. R-pakket versie 0.6.0.
+- Derks, K. (2022). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 - Dyer, D., & Pierce, R.L. (1993). Over de keuze van de voorafgaande verdeling bij hypergeometrische steekproeven. <i>Communicatie in statistiek-theorie en methoden</i>, 22(8), 2125-2146.
 - Stewart, TR (2013). Een Bayesiaans audit assurance-model met toepassing op het component materialiteitsprobleem bij groepsaudits (proefschrift).
 - de Swart, J., Wille, J., & Majoor, B. (2013). Het 'Push-Left'-Principe als Motor van Data Analytics in de Accountantcontrole [Het 'Push-Left'-Principe als aanjager van Data Analytics in Financial Audit]. <i>Maandblad voor Accountancy en Bedrijfseconomie</i>, 87, 425-432.

--- a/inst/help/auditclassicalevaluation.md
+++ b/inst/help/auditclassicalevaluation.md
@@ -122,7 +122,7 @@ You can manually adjust the value of IR and CR by selecting the Custom option un
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.1.
+- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 - Leslie, D. A., Teitlebaum, A. D., Anderson, R. J. (1979). <i>Dollar-unit Sampling: A Practical Guide for Auditors</i>. Toronto: Copp Clark Pitman.
 - Stringer, K.W. (1963) Practical aspects of statistical sampling in auditing. <i>Proceedings of Business and Economic Statistics Section</i>, American Statistical Association.
 - Touw, P., & Hoogduin, L. (2011). Statistiek voor audit en controlling.

--- a/inst/help/auditclassicalevaluation.md
+++ b/inst/help/auditclassicalevaluation.md
@@ -122,9 +122,9 @@ You can manually adjust the value of IR and CR by selecting the Custom option un
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
+- Derks, K. (2022). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 - Leslie, D. A., Teitlebaum, A. D., Anderson, R. J. (1979). <i>Dollar-unit Sampling: A Practical Guide for Auditors</i>. Toronto: Copp Clark Pitman.
-- Stringer, K.W. (1963) Practical aspects of statistical sampling in auditing. <i>Proceedings of Business and Economic Statistics Section</i>, American Statistical Association.
+- Stringer, K. W. (1963) Practical aspects of statistical sampling in auditing. <i>Proceedings of Business and Economic Statistics Section</i>, American Statistical Association.
 - Touw, P., & Hoogduin, L. (2011). Statistiek voor audit en controlling.
 
 ### R Packages

--- a/inst/help/auditclassicalevaluation.md
+++ b/inst/help/auditclassicalevaluation.md
@@ -93,7 +93,7 @@ You can manually adjust the value of IR and CR by selecting the Custom option un
 #### Format Tables
 - Numbers: Display table output as numbers.
 - Percentages: Display table output as percentages.
-- Extrapolated amounts: Display table output as monetary values.
+- Monetary values: Display table output as monetary values.
 
 ### Output
 ---

--- a/inst/help/auditclassicalevaluation.md
+++ b/inst/help/auditclassicalevaluation.md
@@ -122,7 +122,7 @@ You can manually adjust the value of IR and CR by selecting the Custom option un
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.0.
+- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.1.
 - Leslie, D. A., Teitlebaum, A. D., Anderson, R. J. (1979). <i>Dollar-unit Sampling: A Practical Guide for Auditors</i>. Toronto: Copp Clark Pitman.
 - Stringer, K.W. (1963) Practical aspects of statistical sampling in auditing. <i>Proceedings of Business and Economic Statistics Section</i>, American Statistical Association.
 - Touw, P., & Hoogduin, L. (2011). Statistiek voor audit en controlling.

--- a/inst/help/auditclassicalevaluation_nl.md
+++ b/inst/help/auditclassicalevaluation_nl.md
@@ -122,9 +122,9 @@ U kunt de waarde van IR en CR handmatig aanpassen door de optie Aangepast te sel
 ### Referenties
 ---
 - AICPA (2017). <i>Auditgids: controlesteekproeven</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesiaanse en klassieke auditsteekproeven. R-pakket versie 0.6.0.
-- Leslie, D.A., Teitlebaum, A.D., Anderson, R.J. (1979). <i>Sampling in dollars: een praktische gids voor auditors</i>. Toronto: Copp Clark Pitman.
-- Stringer, K.W. (1963) Praktische aspecten van statistische steekproeven bij auditing. <i>Proceedings of Business and Economic Statistics Section</i>, American Statistical Association.
+- Derks, K. (2022). jfa: Bayesiaanse en klassieke auditsteekproeven. R-pakket versie 0.6.2.
+- Leslie, D. A., Teitlebaum, A.D., Anderson, R.J. (1979). <i>Sampling in dollars: een praktische gids voor auditors</i>. Toronto: Copp Clark Pitman.
+- Stringer, K. W. (1963) Praktische aspecten van statistische steekproeven bij auditing. <i>Proceedings of Business and Economic Statistics Section</i>, American Statistical Association.
 - Touw, P., & Hoogduin, L. (2011). Statistiek voor audit en controlling.
 
 ### R-pakketten

--- a/inst/help/auditclassicalplanning.md
+++ b/inst/help/auditclassicalplanning.md
@@ -61,9 +61,9 @@ The expected errors are the tolerable errors that can be found in the sample whi
 - Absolute: Enter your expected errors as the sum of (proportional) errors.
 
 #### Probability distribution
-- Poisson: The Poisson distribution assumes an infinite population size and is therefore generally used when the population size is large. It is a probability distribution that models the rate of misstatement (*\u03B8*) as a function of the observed sample size (*n*) and the sum of the proportional errors (*t*). Because the Poisson distribution accommodates partial errors it is generally used when you are planning a monetary unit sample.
-- Binomial: The binomial distribution assumes an infinite population size and is therefore generally used when the population size is large. It is a probability distribution that models the rate of misstatement (*\u03B8*) as a function of the observed number of errors (*k*) and the number of correct transactions (*n - k*). Because the binomial distribution strictly does not accommodate partial errors, it is generally used when you are not planning a monetary unit sample.
 - Hypergeometric: The hypergeometric distribution assumes a finite population size and is therefore generally used when the population size is small. It is a probability distribution that models the number of errors (*K*) in the population as a function of the population size (*N*), the number of observed found errors (*k*) and the number of correct transactions (*n*).
+- Binomial: The binomial distribution assumes an infinite population size and is therefore generally used when the population size is large. It is a probability distribution that models the rate of misstatement (*\u03B8*) as a function of the observed number of errors (*k*) and the number of correct transactions (*n - k*). Because the binomial distribution strictly does not accommodate partial errors, it is generally used when you are not planning a monetary unit sample.
+- Poisson: The Poisson distribution assumes an infinite population size and is therefore generally used when the population size is large. It is a probability distribution that models the rate of misstatement (*\u03B8*) as a function of the observed sample size (*n*) and the sum of the proportional errors (*t*). Because the Poisson distribution accommodates partial errors it is generally used when you are planning a monetary unit sample.
 
 #### Display
 - Explanatory Text: When checked, enables explanatory text in the analysis to help interpret the procedure and the statistical results.
@@ -95,7 +95,7 @@ The increment alows you to limit the possible sample sizes to a multiple of its 
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.0.
+- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.1.
 - Stewart, T. (2012). <i>Technical notes on the AICPA audit guide Audit Sampling</i>. American Institute of Certified Public Accountants, New York.
 
 ### R Packages

--- a/inst/help/auditclassicalplanning.md
+++ b/inst/help/auditclassicalplanning.md
@@ -96,7 +96,7 @@ The expected errors are the tolerable errors that can be found in the sample whi
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
+- Derks, K. (2022). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 - Stewart, T. (2012). <i>Technical notes on the AICPA audit guide Audit Sampling</i>. American Institute of Certified Public Accountants, New York.
 
 ### R Packages

--- a/inst/help/auditclassicalplanning.md
+++ b/inst/help/auditclassicalplanning.md
@@ -96,7 +96,7 @@ The expected errors are the tolerable errors that can be found in the sample whi
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.1.
+- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 - Stewart, T. (2012). <i>Technical notes on the AICPA audit guide Audit Sampling</i>. American Institute of Certified Public Accountants, New York.
 
 ### R Packages

--- a/inst/help/auditclassicalplanning.md
+++ b/inst/help/auditclassicalplanning.md
@@ -76,8 +76,9 @@ The expected errors are the tolerable errors that can be found in the sample whi
 - Numbers: Display table output as numbers.
 - Percentages: Display table output as percentages.
 
-#### Increment
-The increment alows you to limit the possible sample sizes to a multiple of its value. For example, an increment of 5 allows only sample sizes of 5, 10, 15, 20, 25, etc.
+#### Iterations
+- Increment: The increment alows you to limit the possible sample sizes to a multiple of its value. For example, an increment of 5 allows only sample sizes of 5, 10, 15, 20, 25, etc.
+- Maximum: The maximum allows you to limit the sample size with a maximum.
 
 ### Output
 ---

--- a/inst/help/auditclassicalplanning_nl.md
+++ b/inst/help/auditclassicalplanning_nl.md
@@ -95,7 +95,7 @@ Met de stapgrootte kunt u de mogelijke steekproefomvang beperken tot een veelvou
 ### Referenties
 ---
 - AICPA (2017). <i>Auditgids: controlesteekproeven</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesiaanse en klassieke auditsteekproeven. R-pakket versie 0.6.0.
+- Derks, K. (2022). jfa: Bayesiaanse en klassieke auditsteekproeven. R-pakket versie 0.6.2.
 -Stewart, T. (2012). <i>Technische opmerkingen over de AICPA-auditgids Auditsteekproeven</i>. American Institute of Certified Public Accountants, New York.
 
 ### R-pakketten

--- a/inst/help/auditclassicalworkflow.md
+++ b/inst/help/auditclassicalworkflow.md
@@ -94,8 +94,9 @@ The expected errors are the tolerable errors that can be found in the sample whi
 - Numbers: Display table output as numbers.
 - Percentages: Display table output as percentages.
 
-#### Increment
-The increment alows you to limit the possible sample sizes to a multiple of its value. For example, an increment of 5 allows only sample sizes of 5, 10, 15, 20, 25, etc.
+#### Iterations
+- Increment: The increment alows you to limit the possible sample sizes to a multiple of its value. For example, an increment of 5 allows only sample sizes of 5, 10, 15, 20, 25, etc.
+- Maximum: The maximum allows you to limit the sample size with a maximum.
 
 ### Ouput - Planning
 ---

--- a/inst/help/auditclassicalworkflow.md
+++ b/inst/help/auditclassicalworkflow.md
@@ -239,9 +239,9 @@ Randomizes the items in the population before selection is performed.
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
+- Derks, K. (2022). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 - Leslie, D. A., Teitlebaum, A. D., Anderson, R. J. (1979). <i>Dollar-unit Sampling: A Practical Guide for Auditors</i>. Toronto: Copp Clark Pitman.
-- Stringer, K.W. (1963) Practical aspects of statistical sampling in auditing. <i>Proceedings of Business and Economic Statistics Section</i>, American Statistical Association.
+- Stringer, K. W. (1963) Practical aspects of statistical sampling in auditing. <i>Proceedings of Business and Economic Statistics Section</i>, American Statistical Association.
 - Touw, P., & Hoogduin, L. (2011). Statistiek voor audit en controlling.
 
 ### R Packages

--- a/inst/help/auditclassicalworkflow.md
+++ b/inst/help/auditclassicalworkflow.md
@@ -239,7 +239,7 @@ Randomizes the items in the population before selection is performed.
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.1.
+- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 - Leslie, D. A., Teitlebaum, A. D., Anderson, R. J. (1979). <i>Dollar-unit Sampling: A Practical Guide for Auditors</i>. Toronto: Copp Clark Pitman.
 - Stringer, K.W. (1963) Practical aspects of statistical sampling in auditing. <i>Proceedings of Business and Economic Statistics Section</i>, American Statistical Association.
 - Touw, P., & Hoogduin, L. (2011). Statistiek voor audit en controlling.

--- a/inst/help/auditclassicalworkflow.md
+++ b/inst/help/auditclassicalworkflow.md
@@ -147,7 +147,7 @@ Randomizes the items in the population before selection is performed.
 
 #### Tables
 - Descriptive statistics: Produces a table containing descriptive information about numerical variables in the selection. Statistics that are included are the mean, the median, the standard deviation, the variance, the minimum, the maximum, and the range.
-- Display sample: Produces a table containing the selected transactions along with any additional observations provided in the additional variables field.
+- Selected items: Produces a table containing the selected transactions along with any additional observations provided in the additional variables field.
 
 ### Output - Selection
 ---
@@ -176,7 +176,7 @@ Randomizes the items in the population before selection is performed.
 - Minimum: Minimum of the data points.
 - Maximum: Maximum of the data points.
 
-#### Display Sample
+#### Selected Items
 - Row: The row number of the item.
 - Selected: The number of times (a unit in) the item is selected.
 

--- a/inst/help/auditclassicalworkflow.md
+++ b/inst/help/auditclassicalworkflow.md
@@ -141,12 +141,12 @@ The required number of sampling units that should be selected from the populatio
 - Random sampling: Performs random selection in which each sampling unit has an equal chance of being selected.
   - Seed: Selects the seed for the random number generator in order to reproduce results.
 
-#### Randomize Items
+#### Randomize Item Order
 Randomizes the items in the population before selection is performed.
 
 #### Tables
 - Descriptive statistics: Produces a table containing descriptive information about numerical variables in the selection. Statistics that are included are the mean, the median, the standard deviation, the variance, the minimum, the maximum, and the range.
-- Raw sample: Produces a table containing the selected transactions along with any additional observations provided in the additional variables field.
+- Display sample: Produces a table containing the selected transactions along with any additional observations provided in the additional variables field.
 
 ### Output - Selection
 ---
@@ -175,7 +175,7 @@ Randomizes the items in the population before selection is performed.
 - Minimum: Minimum of the data points.
 - Maximum: Maximum of the data points.
 
-#### Raw Sample
+#### Display Sample
 - Row: The row number of the item.
 - Selected: The number of times (a unit in) the item is selected.
 

--- a/inst/help/auditclassicalworkflow.md
+++ b/inst/help/auditclassicalworkflow.md
@@ -70,9 +70,9 @@ The expected errors are the tolerable errors that can be found in the sample whi
 - Absolute: Enter your expected errors as the sum of (proportional) errors.
 
 #### Probability distribution
-- Poisson: The Poisson distribution assumes an infinite population size and is therefore generally used when the population size is large. It is a probability distribution that models the rate of misstatement (*\u03B8*) as a function of the observed sample size (*n*) and the sum of the proportional errors (*t*). Because the Poisson distribution accommodates partial errors it is generally used when you are planning a monetary unit sample.
-- Binomial: The binomial distribution assumes an infinite population size and is therefore generally used when the population size is large. It is a probability distribution that models the rate of misstatement (*\u03B8*) as a function of the observed number of errors (*k*) and the number of correct transactions (*n - k*). Because the binomial distribution strictly does not accommodate partial errors, it is generally used when you are not planning a monetary unit sample.
 - Hypergeometric: The hypergeometric distribution assumes a finite population size and is therefore generally used when the population size is small. It is a probability distribution that models the number of errors (*K*) in the population as a function of the population size (*N*), the number of observed found errors (*k*) and the number of correct transactions (*n*).
+- Binomial: The binomial distribution assumes an infinite population size and is therefore generally used when the population size is large. It is a probability distribution that models the rate of misstatement (*\u03B8*) as a function of the observed number of errors (*k*) and the number of correct transactions (*n - k*). Because the binomial distribution strictly does not accommodate partial errors, it is generally used when you are not planning a monetary unit sample.
+- Poisson: The Poisson distribution assumes an infinite population size and is therefore generally used when the population size is large. It is a probability distribution that models the rate of misstatement (*\u03B8*) as a function of the observed sample size (*n*) and the sum of the proportional errors (*t*). Because the Poisson distribution accommodates partial errors it is generally used when you are planning a monetary unit sample.
 
 #### Display
 - Explanatory Text: When checked, enables explanatory text in the analysis to help interpret the procedure and the statistical results.
@@ -238,7 +238,7 @@ Randomizes the items in the population before selection is performed.
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.0.
+- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.1.
 - Leslie, D. A., Teitlebaum, A. D., Anderson, R. J. (1979). <i>Dollar-unit Sampling: A Practical Guide for Auditors</i>. Toronto: Copp Clark Pitman.
 - Stringer, K.W. (1963) Practical aspects of statistical sampling in auditing. <i>Proceedings of Business and Economic Statistics Section</i>, American Statistical Association.
 - Touw, P., & Hoogduin, L. (2011). Statistiek voor audit en controlling.

--- a/inst/help/auditclassicalworkflow_nl.md
+++ b/inst/help/auditclassicalworkflow_nl.md
@@ -232,9 +232,9 @@ Randomiseert de items in de populatie voordat de selectie wordt uitgevoerd.
 ### Referenties
 ---
 - AICPA (2017). <i>Auditgids: controlesteekproeven</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesiaanse en klassieke auditsteekproeven. R-pakket versie 0.6.0.
-- Leslie, D.A., Teitlebaum, A.D., Anderson, R.J. (1979). <i>Sampling in dollars: een praktische gids voor auditors</i>. Toronto: Copp Clark Pitman.
-- Stringer, K.W. (1963) Praktische aspecten van statistische steekproeven bij auditing. <i>Proceedings of Business and Economic Statistics Section</i>, American Statistical Association.
+- Derks, K. (2022). jfa: Bayesiaanse en klassieke auditsteekproeven. R-pakket versie 0.6.2.
+- Leslie, D. A., Teitlebaum, A.D., Anderson, R.J. (1979). <i>Sampling in dollars: een praktische gids voor auditors</i>. Toronto: Copp Clark Pitman.
+- Stringer, K. W. (1963) Praktische aspecten van statistische steekproeven bij auditing. <i>Proceedings of Business and Economic Statistics Section</i>, American Statistical Association.
 - Touw, P., & Hoogduin, L. (2011). Statistiek voor audit en controlling.
 
 ### R-pakketten

--- a/inst/help/auditselection.md
+++ b/inst/help/auditselection.md
@@ -78,7 +78,7 @@ When a name is provided, adds the result from the selection analysis in a new co
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
+- Derks, K. (2022). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 
 ### R Packages
 ---

--- a/inst/help/auditselection.md
+++ b/inst/help/auditselection.md
@@ -31,7 +31,7 @@ The required number of sampling units that should be selected from the populatio
 - Random sampling: Performs random selection in which each sampling unit has an equal chance of being selected.
   - Seed: Selects the seed for the random number generator in order to reproduce results.
 
-#### Randomize Items
+#### Randomize Item Order
 Randomizes the items in the population before selection is performed.
 
 #### Display
@@ -42,7 +42,7 @@ When a name is provided, adds the result from the selection analysis in a new co
 
 #### Tables
 - Descriptive statistics: Produces a table containing descriptive information about numerical variables in the selection. Statistics that are included are the mean, the median, the standard deviation, the variance, the minimum, the maximum, and the range.
-- Raw sample: Produces a table containing the selected transactions along with any additional observations provided in the additional variables field.
+- Display sample: Produces a table containing the selected transactions along with any additional observations provided in the additional variables field.
 
 ### Output
 ---
@@ -71,7 +71,7 @@ When a name is provided, adds the result from the selection analysis in a new co
 - Minimum: Minimum of the data points.
 - Maximum: Maximum of the data points.
 
-#### Raw Sample
+#### Display Sample
 - Row: The row number of the item.
 - Selected: The number of times (a unit in) the item is selected.
 

--- a/inst/help/auditselection.md
+++ b/inst/help/auditselection.md
@@ -78,7 +78,7 @@ When a name is provided, adds the result from the selection analysis in a new co
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.1.
+- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.2.
 
 ### R Packages
 ---

--- a/inst/help/auditselection.md
+++ b/inst/help/auditselection.md
@@ -42,7 +42,7 @@ When a name is provided, adds the result from the selection analysis in a new co
 
 #### Tables
 - Descriptive statistics: Produces a table containing descriptive information about numerical variables in the selection. Statistics that are included are the mean, the median, the standard deviation, the variance, the minimum, the maximum, and the range.
-- Display sample: Produces a table containing the selected transactions along with any additional observations provided in the additional variables field.
+- Selected items: Produces a table containing the selected transactions along with any additional observations provided in the additional variables field.
 
 ### Output
 ---
@@ -71,7 +71,7 @@ When a name is provided, adds the result from the selection analysis in a new co
 - Minimum: Minimum of the data points.
 - Maximum: Maximum of the data points.
 
-#### Display Sample
+#### Selected Items
 - Row: The row number of the item.
 - Selected: The number of times (a unit in) the item is selected.
 

--- a/inst/help/auditselection.md
+++ b/inst/help/auditselection.md
@@ -78,7 +78,7 @@ When a name is provided, adds the result from the selection analysis in a new co
 ### References
 ---
 - AICPA (2017). <i>Audit Guide: Audit Sampling</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.0.
+- Derks, K (2021). jfa: Bayesian and Classical Audit Sampling. R package version 0.6.1.
 
 ### R Packages
 ---

--- a/inst/help/auditselection_nl.md
+++ b/inst/help/auditselection_nl.md
@@ -78,7 +78,7 @@ Wanneer een naam is opgegeven, wordt het resultaat van de selectieanalyse in een
 ### Referenties
 ---
 - AICPA (2017). <i>Auditgids: controlesteekproeven</i>. American Institute of Certified Public Accountants.
-- Derks, K (2021). jfa: Bayesiaanse en klassieke auditsteekproeven. R-pakket versie 0.6.0.
+- Derks, K. (2022). jfa: Bayesiaanse en klassieke auditsteekproeven. R-pakket versie 0.6.2.
 
 ### R-pakketten
 ---

--- a/inst/qml/auditBayesianEvaluation.qml
+++ b/inst/qml/auditBayesianEvaluation.qml
@@ -108,7 +108,6 @@ Form
 							name: 				"materiality_abs"
 							text: 				qsTr("Absolute")
 							childrenOnSameRow: 	true
-							onCheckedChanged:	if (checked) poisson.click()
 
 							DoubleField
 							{
@@ -589,7 +588,7 @@ Form
 		{
 			id: 								expected
 			name: 								"expected_type"
-			title: 								qsTr("Expected Errors in Sample")
+			title: 								qsTr("Prior Expected Error Rate")
 			enabled:							arm.checked || impartial.checked
 
 			RadioButton

--- a/inst/qml/auditBayesianEvaluation.qml
+++ b/inst/qml/auditBayesianEvaluation.qml
@@ -251,7 +251,7 @@ Form
 		{
 			id: 								data
 			name: 								"data"
-			label:								qsTr("Raw")
+			label:								qsTr("Columns")
 			checked: 							mainWindow.dataAvailable
 			enabled:							mainWindow.dataAvailable
 		}
@@ -613,28 +613,9 @@ Form
 
 			RadioButton
 			{
-				id: 							expected_abs
-				name: 							"expected_abs"
-				text: 							qsTr("Absolute")
-				childrenOnSameRow: 				true
-
-				DoubleField
-				{
-					id:							expected_abs_val
-					name: 						"expected_abs_val"
-					enabled: 					expected_abs.checked
-					defaultValue: 				0
-					min: 						0
-					decimals: 					2
-					visible: 					expected_abs.checked
-				}
-			}
-
-			RadioButton
-			{
 				name:							"expected_all"
 				text:							qsTr("All possible")
-				visible:						separate.checked
+				enabled:						separate.checked
 			}
 		}
 	}

--- a/inst/qml/auditBayesianEvaluation.qml
+++ b/inst/qml/auditBayesianEvaluation.qml
@@ -698,7 +698,7 @@ Form
 
 			RadioButton
 			{
-				text: 							qsTr("Extrapolated amounts")
+				text: 							qsTr("Monetary values")
 				name: 							"amount"
 				enabled:						n_units.value > 0
 			}

--- a/inst/qml/auditBayesianEvaluation.qml
+++ b/inst/qml/auditBayesianEvaluation.qml
@@ -316,10 +316,10 @@ Form
 
 		RadioButton
 		{
-			id:									poisson
-			name: 								"poisson"
-			text: 								qsTr("Gamma")
-			checked: 							true
+			id:									hypergeometric
+			name: 								"hypergeometric"
+			text: 								qsTr("Beta-binomial")
+			enabled: 							n_units.value > 0
 		}
 
 		RadioButton
@@ -327,14 +327,14 @@ Form
 			id:									binomial
 			name: 								"binomial"
 			text: 								qsTr("Beta")
+			checked: 							true
 		}
 
 		RadioButton
 		{
-			id:									hypergeometric
-			name: 								"hypergeometric"
-			text: 								qsTr("Beta-binomial")
-			enabled: 							n_units.value > 0
+			id:									poisson
+			name: 								"poisson"
+			text: 								qsTr("Gamma")
 		}
 	}
 

--- a/inst/qml/auditBayesianPlanning.qml
+++ b/inst/qml/auditBayesianPlanning.qml
@@ -166,7 +166,6 @@ Form
 				fieldWidth: 					100 * preferencesModel.uiScale
 				min: 							0
 				decimals: 						2
-				onValueChanged:					if (n_units.value == 0) poisson.click()
 			}
 		}
 

--- a/inst/qml/auditBayesianPlanning.qml
+++ b/inst/qml/auditBayesianPlanning.qml
@@ -247,7 +247,6 @@ Form
 	{
 		title: 									qsTr("Probability Distribution")
 		name: 									"likelihood"
-		columns: 2
 
 		RadioButton
 		{
@@ -255,11 +254,6 @@ Form
 			text: 								qsTr("Beta-binomial")
 			name: 								"hypergeometric"
 			enabled:							n_units.value > 0
-		}
-
-		HelpButton
-		{
-			toolTip: 							qsTr("This distribution assumes you are working with a finite population.")
 		}
 
 		RadioButton
@@ -270,21 +264,11 @@ Form
 			checked: 							true
 		}
 
-		HelpButton
-		{
-			toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
-		}
-
 		RadioButton
 		{
 			id: 								poisson
 			text: 								qsTr("Gamma")
 			name: 								"poisson"
-		}
-
-		HelpButton
-		{
-			toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
 		}
 	}
 

--- a/inst/qml/auditBayesianPlanning.qml
+++ b/inst/qml/auditBayesianPlanning.qml
@@ -510,13 +510,25 @@ Form
 			}
 		}
 
-		IntegerField
+		Group
 		{
-			name: 								"by"
-			text: 								qsTr("Increment")
-			min: 								1
-			max:								50
-			defaultValue: 						1
+			title:								qsTr("Iterations")
+			IntegerField
+			{
+				name: 							"by"
+				text: 							qsTr("Increment")
+				min: 							1
+				max:							50
+				defaultValue: 					1
+			}
+
+			IntegerField
+			{
+				name: 							"max"
+				text: 							qsTr("Maximum")
+				min: 							1
+				defaultValue: 					5000
+			}
 		}
 	}
 

--- a/inst/qml/auditBayesianPlanning.qml
+++ b/inst/qml/auditBayesianPlanning.qml
@@ -105,7 +105,6 @@ Form
 							name: 				"materiality_abs"
 							text: 				qsTr("Absolute")
 							childrenOnSameRow: 	true
-							onCheckedChanged:	if (checked) poisson.click()
 
 							DoubleField
 							{

--- a/inst/qml/auditBayesianPlanning.qml
+++ b/inst/qml/auditBayesianPlanning.qml
@@ -248,6 +248,7 @@ Form
 	{
 		title: 									qsTr("Probability Distribution")
 		name: 									"likelihood"
+		columns: 2
 
 		RadioButton
 		{
@@ -255,6 +256,11 @@ Form
 			text: 								qsTr("Beta-binomial")
 			name: 								"hypergeometric"
 			enabled:							n_units.value > 0
+		}
+
+		HelpButton
+		{
+			toolTip: 							qsTr("This distribution assumes you are working with a finite population.")
 		}
 
 		RadioButton
@@ -265,11 +271,21 @@ Form
 			checked: 							true
 		}
 
+		HelpButton
+		{
+			toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
+		}
+
 		RadioButton
 		{
 			id: 								poisson
 			text: 								qsTr("Gamma")
 			name: 								"poisson"
+		}
+
+		HelpButton
+		{
+			toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
 		}
 	}
 

--- a/inst/qml/auditBayesianPlanning.qml
+++ b/inst/qml/auditBayesianPlanning.qml
@@ -252,10 +252,10 @@ Form
 
 		RadioButton
 		{
-			id: 								poisson
-			text: 								qsTr("Gamma")
-			name: 								"poisson"
-			checked: 							true
+			id: 								hypergeometric
+			text: 								qsTr("Beta-binomial")
+			name: 								"hypergeometric"
+			enabled:							n_units.value > 0
 		}
 
 		RadioButton
@@ -263,14 +263,14 @@ Form
 			id: 								binomial
 			text: 								qsTr("Beta")
 			name: 								"binomial"
+			checked: 							true
 		}
 
 		RadioButton
 		{
-			id: 								hypergeometric
-			text: 								qsTr("Beta-binomial")
-			name: 								"hypergeometric"
-			enabled:							n_units.value > 0
+			id: 								poisson
+			text: 								qsTr("Gamma")
+			name: 								"poisson"
 		}
 	}
 

--- a/inst/qml/auditBayesianWorkflow.qml
+++ b/inst/qml/auditBayesianWorkflow.qml
@@ -606,7 +606,7 @@ Form
 
 				RadioButton
 				{
-					text: 							qsTr("Extrapolated amounts")
+					text: 							qsTr("Monetary values")
 					name: 							"amount"
 					enabled:						values.count > 0
 				}

--- a/inst/qml/auditBayesianWorkflow.qml
+++ b/inst/qml/auditBayesianWorkflow.qml
@@ -628,14 +628,27 @@ Form
 				}
 			}
 
-			IntegerField
+			Group
 			{
-				name: 								"by"
-				text: 								qsTr("Increment")
-				min: 								1
-				max:								50
-				defaultValue: 						1
+				title:								qsTr("Iterations")
 				enabled:							!pasteVariables.checked
+
+				IntegerField
+				{
+					name: 							"by"
+					text: 							qsTr("Increment")
+					min: 							1
+					max:							50
+					defaultValue: 					1
+				}
+
+				IntegerField
+				{
+					name: 							"max"
+					text: 							qsTr("Maximum")
+					min: 							1
+					defaultValue: 					5000
+				}
 			}
 
 			Group

--- a/inst/qml/auditBayesianWorkflow.qml
+++ b/inst/qml/auditBayesianWorkflow.qml
@@ -302,10 +302,10 @@ Form
 
 			RadioButton
 			{
-				id: 								lik_poisson
-				text: 								qsTr("Gamma")
-				name: 								"poisson"
-				checked:							true
+				id: 								lik_hypergeometric
+				text: 								qsTr("Beta-binomial")
+				name: 								"hypergeometric"
+				enabled:							id.count > 0
 			}
 
 			RadioButton
@@ -313,14 +313,14 @@ Form
 				id: 								lik_binomial
 				text: 								qsTr("Beta")
 				name: 								"binomial"
+				checked:							true
 			}
 
 			RadioButton
 			{
-				id: 								lik_hypergeometric
-				text: 								qsTr("Beta-binomial")
-				name: 								"hypergeometric"
-				enabled:							id.count > 0
+				id: 								lik_poisson
+				text: 								qsTr("Gamma")
+				name: 								"poisson"
 			}
 		}
 
@@ -1149,10 +1149,10 @@ Form
 
 			RadioButton
 			{
-				id: 								poisson
-				name: 								"poisson"
-				text: 								qsTr("Gamma")
-				enabled: 							lik_poisson.checked
+				id: 								hypergeometric
+				name: 								"hypergeometric"
+				text: 								qsTr("Beta-binomial")
+				enabled: 							lik_hypergeometric.checked
 			}
 
 			RadioButton
@@ -1165,10 +1165,10 @@ Form
 
 			RadioButton
 			{
-				id: 								hypergeometric
-				name: 								"hypergeometric"
-				text: 								qsTr("Beta-binomial")
-				enabled: 							lik_hypergeometric.checked
+				id: 								poisson
+				name: 								"poisson"
+				text: 								qsTr("Gamma")
+				enabled: 							lik_poisson.checked
 			}
 		}
 

--- a/inst/qml/auditBayesianWorkflow.qml
+++ b/inst/qml/auditBayesianWorkflow.qml
@@ -269,7 +269,7 @@ Form
 			{
 				name:								"expected_all"
 				text:								qsTr("All possible")
-				visible:							separate.checked
+				enabled:							separate.checked
 			}
 		}
 

--- a/inst/qml/auditBayesianWorkflow.qml
+++ b/inst/qml/auditBayesianWorkflow.qml
@@ -791,7 +791,7 @@ Form
 
 			CheckBox
 			{
-				text: 								qsTr("Display sample")
+				text: 								qsTr("Selected items")
 				name: 								"tableSample"
 			}
 		}

--- a/inst/qml/auditBayesianWorkflow.qml
+++ b/inst/qml/auditBayesianWorkflow.qml
@@ -198,7 +198,7 @@ Form
 				singleVariable:						true
 				allowedColumns:						["nominal", "nominalText", "ordinal", "scale"]
 				allowAnalysisOwnComputedColumns: 	false
-				onCountChanged:						if(lik_hypergeometric.checked && id.count == 0) lik_poisson.click()
+				onCountChanged:						if(lik_hypergeometric.checked && id.count == 0) lik_binomial.click()
 			}
 
 			AssignedVariablesList

--- a/inst/qml/auditBayesianWorkflow.qml
+++ b/inst/qml/auditBayesianWorkflow.qml
@@ -299,6 +299,7 @@ Form
 			title: 									qsTr("Probability Distribution")
 			name: 									"likelihood"
 			enabled:								!pasteVariables.checked
+			columns:								2
 
 			RadioButton
 			{
@@ -306,6 +307,11 @@ Form
 				text: 								qsTr("Beta-binomial")
 				name: 								"hypergeometric"
 				enabled:							id.count > 0
+			}
+
+			HelpButton
+			{
+				toolTip: 							qsTr("This distribution assumes you are working with a finite population.")
 			}
 
 			RadioButton
@@ -316,11 +322,21 @@ Form
 				checked:							true
 			}
 
+			HelpButton
+			{
+				toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
+			}
+
 			RadioButton
 			{
 				id: 								lik_poisson
 				text: 								qsTr("Gamma")
 				name: 								"poisson"
+			}
+
+			HelpButton
+			{
+				toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
 			}
 		}
 
@@ -730,8 +746,6 @@ Form
 
 		Group
 		{
-			rowSpacing: 							15 * preferencesModel.uiScale
-
 			IntegerField
 			{
 				id: 								seed
@@ -742,6 +756,36 @@ Form
 				max: 								99999
 				enabled:							(randomize.checked || method.value != "interval") & !separate.checked
 			}
+
+			CheckBox
+			{
+				id:									randomize
+				name:								"randomize"
+				text:								qsTr("Randomize item order")
+				enabled:							!pasteVariables.checked && !separate.checked && rank.count == 0
+			}
+		}
+
+		Group
+		{
+			title: 									qsTr("Tables")
+
+			CheckBox
+			{
+				text: 								qsTr("Descriptive statistics")
+				name: 								"tableDescriptives"
+			}
+
+			CheckBox
+			{
+				text: 								qsTr("Display sample")
+				name: 								"tableSample"
+			}
+		}
+
+		Group
+		{
+			rowSpacing: 							15 * preferencesModel.uiScale
 
 			RadioButtonGroup
 			{
@@ -780,107 +824,67 @@ Form
 					toolTip: 						qsTr("Click to learn more about monetary unit sampling.")
 				}
 			}
-		}
 
-		Group
-		{
-			title: 									qsTr("Tables")
-
-			CheckBox
-			{
-				text: 								qsTr("Descriptive statistics")
-				name: 								"tableDescriptives"
-			}
-
-			CheckBox
-			{
-				text: 								qsTr("Raw sample")
-				name: 								"tableSample"
-			}
-		}
-
-		Group
-		{
 			RadioButtonGroup
 			{
 				id: 								method
 				title:								qsTr("Method")
 				name: 								"sampling_method"
 				enabled:							!pasteVariables.checked
+				columns:							2
 
-				Group
+				RadioButton
 				{
+					id: 							interval
+					text: 							qsTr("Fixed interval sampling")
+					name: 							"interval"
+					checked: 						true
 
-					Row
+					IntegerField
 					{
-						RadioButton
-						{
-							id: 					interval
-							text: 					qsTr("Fixed interval sampling")
-							name: 					"interval"
-							checked: 				true
-
-							IntegerField
-							{
-								id: 				start
-								text: 				qsTr("Starting point")
-								name: 				"start"
-								defaultValue: 		1
-								min: 				1
-								visible:			interval.checked
-								enabled:			!separate.checked
-							}
-						}
-
-						HelpButton
-						{
-							toolTip: 				qsTr("Click to learn more about fixed interval sampling.")
-							helpPage:				"Audit/fixedIntervalSampling"
-						}
-					}
-
-					Row
-					{
-						RadioButton
-						{
-							id: 					cell
-							text: 					qsTr("Cell sampling")
-							name: 					"cell"
-							enabled:				!separate.checked
-						}
-
-						HelpButton
-						{
-							toolTip: 				qsTr("Click to learn more about cell sampling.")
-							helpPage:				"Audit/cellSampling"
-						}
-					}
-
-					Row
-					{
-						RadioButton
-						{
-							id: 					random
-							text: 					qsTr("Random sampling")
-							name: 					"random"
-							enabled:				!separate.checked
-						}
-
-						HelpButton
-						{
-							toolTip: 				qsTr("Click to learn more about random sampling.")
-							helpPage:				"Audit/randomSampling"
-						}
+						id: 						start
+						text: 						qsTr("Starting point")
+						name: 						"start"
+						defaultValue: 				1
+						min: 						1
+						visible:					interval.checked
+						enabled:					!separate.checked
 					}
 				}
-			}
 
-			CheckBox
-			{
-				id:									randomize
-				name:								"randomize"
-				text:								qsTr("Randomize items")
-				enabled:							!pasteVariables.checked && !separate.checked && rank.count == 0
+				HelpButton
+				{
+					toolTip: 						qsTr("Click to learn more about fixed interval sampling.")
+					helpPage:						"Audit/fixedIntervalSampling"
+				}
+
+				RadioButton
+				{
+					id: 							cell
+					text: 							qsTr("Cell sampling")
+					name: 							"cell"
+					enabled:						!separate.checked
+				}
+
+				HelpButton
+				{
+					toolTip: 						qsTr("Click to learn more about cell sampling.")
+					helpPage:						"Audit/cellSampling"
+				}
+
+				RadioButton
+				{
+					id: 							random
+					text: 							qsTr("Random sampling")
+					name: 							"random"
+					enabled:						!separate.checked
+				}
+
+				HelpButton
+				{
+					toolTip: 						qsTr("Click to learn more about random sampling.")
+					helpPage:						"Audit/randomSampling"
+				}
 			}
 		}
 

--- a/inst/qml/auditBayesianWorkflow.qml
+++ b/inst/qml/auditBayesianWorkflow.qml
@@ -299,7 +299,6 @@ Form
 			title: 									qsTr("Probability Distribution")
 			name: 									"likelihood"
 			enabled:								!pasteVariables.checked
-			columns:								2
 
 			RadioButton
 			{
@@ -307,11 +306,6 @@ Form
 				text: 								qsTr("Beta-binomial")
 				name: 								"hypergeometric"
 				enabled:							id.count > 0
-			}
-
-			HelpButton
-			{
-				toolTip: 							qsTr("This distribution assumes you are working with a finite population.")
 			}
 
 			RadioButton
@@ -322,21 +316,11 @@ Form
 				checked:							true
 			}
 
-			HelpButton
-			{
-				toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
-			}
-
 			RadioButton
 			{
 				id: 								lik_poisson
 				text: 								qsTr("Gamma")
 				name: 								"poisson"
-			}
-
-			HelpButton
-			{
-				toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
 			}
 		}
 

--- a/inst/qml/auditClassicalEvaluation.qml
+++ b/inst/qml/auditClassicalEvaluation.qml
@@ -127,7 +127,6 @@ Form
 							name: 				"materiality_abs"
 							text: 				qsTr("Absolute")
 							childrenOnSameRow: 	true
-							onCheckedChanged:	if (checked) poisson.click()
 
 							DoubleField
 							{

--- a/inst/qml/auditClassicalEvaluation.qml
+++ b/inst/qml/auditClassicalEvaluation.qml
@@ -404,22 +404,22 @@ Form
 
 		RadioButton
 		{
-			name: 							"poisson"
-			text: 							qsTr("Poisson")
-			checked:						true
+			name: 							"hypergeometric"
+			text: 							qsTr("Hypergeometric")
+			enabled:						n_units.value > 0
 		}
 
 		RadioButton
 		{
 			name: 							"binomial"
 			text: 							qsTr("Binomial")
+			checked:						true
 		}
 
 		RadioButton
 		{
-			name: 							"hypergeometric"
-			text: 							qsTr("Hypergeometric")
-			enabled:						n_units.value > 0
+			name: 							"poisson"
+			text: 							qsTr("Poisson")
 		}
 
 		RadioButton

--- a/inst/qml/auditClassicalEvaluation.qml
+++ b/inst/qml/auditClassicalEvaluation.qml
@@ -562,7 +562,7 @@ Form
 
 			RadioButton
 			{
-				text: 							qsTr("Extrapolated amounts")
+				text: 							qsTr("Monetary values")
 				name: 							"amount"
 				enabled:						n_units.value != 0
 			}

--- a/inst/qml/auditClassicalEvaluation.qml
+++ b/inst/qml/auditClassicalEvaluation.qml
@@ -270,7 +270,7 @@ Form
 		{
 			id: 								data
 			name: 								"data"
-			label:								qsTr("Raw")
+			label:								qsTr("Columns")
 			checked: 							mainWindow.dataAvailable
 			enabled:							mainWindow.dataAvailable
 		}

--- a/inst/qml/auditClassicalPlanning.qml
+++ b/inst/qml/auditClassicalPlanning.qml
@@ -345,7 +345,7 @@ Form
 
 		HelpButton
 		{
-			toolTip: 						qsTr("This distribution assumes you are working with a finite population.")
+			toolTip: 							qsTr("This distribution assumes you are working with a finite population.")
 		}
 
 		RadioButton
@@ -358,7 +358,7 @@ Form
 
 		HelpButton
 		{
-			toolTip: 						qsTr("This distribution assumes you are working with an infinite population.")
+			toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
 		}
 
 		RadioButton
@@ -370,7 +370,7 @@ Form
 
 		HelpButton
 		{
-			toolTip: 						qsTr("This distribution assumes you are working with an infinite population.")
+			toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
 		}
 	}
 
@@ -398,13 +398,25 @@ Form
 			}
 		}
 
-		IntegerField
+		Group
 		{
-			name: 								"by"
-			text: 								qsTr("Increment")
-			min: 								1
-			max:								50
-			defaultValue: 						1
+			title:								qsTr("Iterations")
+			IntegerField
+			{
+				name: 							"by"
+				text: 							qsTr("Increment")
+				min: 							1
+				max:							50
+				defaultValue: 					1
+			}
+
+			IntegerField
+			{
+				name: 							"max"
+				text: 							qsTr("Maximum")
+				min: 							1
+				defaultValue: 					5000
+			}
 		}
 	}
 

--- a/inst/qml/auditClassicalPlanning.qml
+++ b/inst/qml/auditClassicalPlanning.qml
@@ -332,7 +332,6 @@ Form
 	{
 		title: 									qsTr("Probability Distribution")
 		name: 									"likelihood"
-		columns:								2
 
 		RadioButton
 		{
@@ -340,11 +339,6 @@ Form
 			text: 								qsTr("Hypergeometric")
 			name: 								"hypergeometric"
 			enabled:							n_units.value > 0
-		}
-
-		HelpButton
-		{
-			toolTip: 							qsTr("This distribution assumes you are working with a finite population.")
 		}
 
 		RadioButton
@@ -355,21 +349,11 @@ Form
 			checked:							true
 		}
 
-		HelpButton
-		{
-			toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
-		}
-
 		RadioButton
 		{
 			id: 								poisson
 			text: 								qsTr("Poisson")
 			name: 								"poisson"
-		}
-
-		HelpButton
-		{
-			toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
 		}
 	}
 

--- a/inst/qml/auditClassicalPlanning.qml
+++ b/inst/qml/auditClassicalPlanning.qml
@@ -177,7 +177,6 @@ Form
 				fieldWidth: 					100 * preferencesModel.uiScale
 				min: 							0
 				decimals: 						2
-				onValueChanged:					if (n_units.value == 0) poisson.click()
 			}
 		}
 

--- a/inst/qml/auditClassicalPlanning.qml
+++ b/inst/qml/auditClassicalPlanning.qml
@@ -333,6 +333,7 @@ Form
 	{
 		title: 									qsTr("Probability Distribution")
 		name: 									"likelihood"
+		columns:								2
 
 		RadioButton
 		{
@@ -340,6 +341,11 @@ Form
 			text: 								qsTr("Hypergeometric")
 			name: 								"hypergeometric"
 			enabled:							n_units.value > 0
+		}
+
+		HelpButton
+		{
+			toolTip: 						qsTr("This distribution assumes you are working with a finite population.")
 		}
 
 		RadioButton
@@ -350,11 +356,21 @@ Form
 			checked:							true
 		}
 
+		HelpButton
+		{
+			toolTip: 						qsTr("This distribution assumes you are working with an infinite population.")
+		}
+
 		RadioButton
 		{
 			id: 								poisson
 			text: 								qsTr("Poisson")
 			name: 								"poisson"
+		}
+
+		HelpButton
+		{
+			toolTip: 						qsTr("This distribution assumes you are working with an infinite population.")
 		}
 	}
 

--- a/inst/qml/auditClassicalPlanning.qml
+++ b/inst/qml/auditClassicalPlanning.qml
@@ -273,7 +273,6 @@ Form
 		id: 									expected
 		name: 									"expected_type"
 		title: 									qsTr("Expected Errors in Sample")
-		enabled:								ir.value == 'high' && cr.value == 'high'
 
 		RadioButton
 		{
@@ -338,10 +337,10 @@ Form
 
 		RadioButton
 		{
-			id: 								poisson
-			text: 								qsTr("Poisson")
-			name: 								"poisson"
-			checked: 							true
+			id: 								hypergeometric
+			text: 								qsTr("Hypergeometric")
+			name: 								"hypergeometric"
+			enabled:							n_units.value > 0
 		}
 
 		RadioButton
@@ -349,14 +348,14 @@ Form
 			id: 								binomial
 			text: 								qsTr("Binomial")
 			name: 								"binomial"
+			checked:							true
 		}
 
 		RadioButton
 		{
-			id: 								hypergeometric
-			text: 								qsTr("Hypergeometric")
-			name: 								"hypergeometric"
-			enabled:							n_units.value > 0
+			id: 								poisson
+			text: 								qsTr("Poisson")
+			name: 								"poisson"
 		}
 	}
 

--- a/inst/qml/auditClassicalPlanning.qml
+++ b/inst/qml/auditClassicalPlanning.qml
@@ -116,7 +116,6 @@ Form
 							name: 				"materiality_abs"
 							text: 				qsTr("Absolute")
 							childrenOnSameRow: 	true
-							onCheckedChanged:	if (checked) poisson.click()
 
 							DoubleField
 							{

--- a/inst/qml/auditClassicalWorkflow.qml
+++ b/inst/qml/auditClassicalWorkflow.qml
@@ -382,6 +382,7 @@ Form
 			title: 									qsTr("Probability Distribution")
 			name: 									"likelihood"
 			enabled:								!pasteVariables.checked
+			columns:								2
 
 			RadioButton
 			{
@@ -389,6 +390,11 @@ Form
 				text: 								qsTr("Hypergeometric")
 				name: 								"hypergeometric"
 				enabled:							id.count > 0
+			}
+
+			HelpButton
+			{
+				toolTip: 							qsTr("This distribution assumes you are working with a finite population.")
 			}
 
 			RadioButton
@@ -399,11 +405,21 @@ Form
 				checked: 							true
 			}
 
+			HelpButton
+			{
+				toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
+			}
+
 			RadioButton
 			{
 				id: 								lik_poisson
 				text: 								qsTr("Poisson")
 				name: 								"poisson"
+			}
+
+			HelpButton
+			{
+				toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
 			}
 		}
 
@@ -602,8 +618,6 @@ Form
 
 		Group
 		{
-			rowSpacing: 							15 * preferencesModel.uiScale
-
 			IntegerField
 			{
 				id: 								seed
@@ -614,6 +628,36 @@ Form
 				max: 								99999
 				enabled:							randomize.checked || method.value != "interval"
 			}
+
+			CheckBox
+			{
+				id:									randomize
+				name:								"randomize"
+				text:								qsTr("Randomize item order")
+				enabled:							!pasteVariables.checked && rank.count == 0
+			}
+		}
+
+		Group
+		{
+			title: 									qsTr("Tables")
+
+			CheckBox
+			{
+				text: 								qsTr("Descriptive statistics")
+				name: 								"tableDescriptives"
+			}
+
+			CheckBox
+			{
+				text: 								qsTr("Display sample")
+				name: 								"tableSample"
+			}
+		}
+
+		Group
+		{
+			rowSpacing: 							15 * preferencesModel.uiScale
 
 			RadioButtonGroup
 			{
@@ -651,104 +695,64 @@ Form
 					toolTip: 						qsTr("Click to learn more about monetary unit sampling.")
 				}
 			}
-		}
 
-		Group
-		{
-			title: 									qsTr("Tables")
-
-			CheckBox
-			{
-				text: 								qsTr("Descriptive statistics")
-				name: 								"tableDescriptives"
-			}
-
-			CheckBox
-			{
-				text: 								qsTr("Raw sample")
-				name: 								"tableSample"
-			}
-		}
-
-		Group
-		{
 			RadioButtonGroup
 			{
 				id: 								method
 				title:								qsTr("Method")
 				name: 								"sampling_method"
 				enabled:							!pasteVariables.checked
+				columns:							2
 
-				Group
+				RadioButton
 				{
+					id: 							interval
+					text: 							qsTr("Fixed interval sampling")
+					name: 							"interval"
+					checked: 						true
 
-					Row
+					IntegerField
 					{
-						RadioButton
-						{
-							id: 					interval
-							text: 					qsTr("Fixed interval sampling")
-							name: 					"interval"
-							checked: 				true
-
-							IntegerField
-							{
-								id: 				start
-								text: 				qsTr("Starting point")
-								name: 				"start"
-								defaultValue: 		1
-								min: 				1
-								visible:			interval.checked
-							}
-						}
-
-						HelpButton
-						{
-							toolTip: 				qsTr("Click to learn more about fixed interval sampling.")
-							helpPage:				"Audit/fixedIntervalSampling"
-						}
-					}
-
-					Row
-					{
-						RadioButton
-						{
-							id: 					cell
-							text: 					qsTr("Cell sampling")
-							name: 					"cell"
-						}
-
-						HelpButton
-						{
-							toolTip: 				qsTr("Click to learn more about cell sampling.")
-							helpPage:				"Audit/cellSampling"
-						}
-					}
-
-					Row
-					{
-						RadioButton
-						{
-							id: 					random
-							text: 					qsTr("Random sampling")
-							name: 					"random"
-						}
-
-						HelpButton
-						{
-							toolTip: 				qsTr("Click to learn more about random sampling.")
-							helpPage:				"Audit/randomSampling"
-						}
+						id: 						start
+						text: 						qsTr("Starting point")
+						name: 						"start"
+						defaultValue: 				1
+						min: 						1
+						visible:					interval.checked
 					}
 				}
-			}
 
-			CheckBox
-			{
-				id:									randomize
-				name:								"randomize"
-				text:								qsTr("Randomize items")
-				enabled:							!pasteVariables.checked && rank.count == 0
+				HelpButton
+				{
+					toolTip: 						qsTr("Click to learn more about fixed interval sampling.")
+					helpPage:						"Audit/fixedIntervalSampling"
+				}
+
+				RadioButton
+				{
+					id: 							cell
+					text: 							qsTr("Cell sampling")
+					name: 							"cell"
+				}
+
+				HelpButton
+				{
+					toolTip: 						qsTr("Click to learn more about cell sampling.")
+					helpPage:						"Audit/cellSampling"
+				}
+
+				RadioButton
+				{
+					id: 							random
+					text: 							qsTr("Random sampling")
+					name: 							"random"
+				}
+
+				HelpButton
+				{
+					toolTip: 						qsTr("Click to learn more about random sampling.")
+					helpPage:						"Audit/randomSampling"
+				}
 			}
 		}
 

--- a/inst/qml/auditClassicalWorkflow.qml
+++ b/inst/qml/auditClassicalWorkflow.qml
@@ -382,7 +382,6 @@ Form
 			title: 									qsTr("Probability Distribution")
 			name: 									"likelihood"
 			enabled:								!pasteVariables.checked
-			columns:								2
 
 			RadioButton
 			{
@@ -390,11 +389,6 @@ Form
 				text: 								qsTr("Hypergeometric")
 				name: 								"hypergeometric"
 				enabled:							id.count > 0
-			}
-
-			HelpButton
-			{
-				toolTip: 							qsTr("This distribution assumes you are working with a finite population.")
 			}
 
 			RadioButton
@@ -405,21 +399,11 @@ Form
 				checked: 							true
 			}
 
-			HelpButton
-			{
-				toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
-			}
-
 			RadioButton
 			{
 				id: 								lik_poisson
 				text: 								qsTr("Poisson")
 				name: 								"poisson"
-			}
-
-			HelpButton
-			{
-				toolTip: 							qsTr("This distribution assumes you are working with an infinite population.")
 			}
 		}
 

--- a/inst/qml/auditClassicalWorkflow.qml
+++ b/inst/qml/auditClassicalWorkflow.qml
@@ -501,7 +501,7 @@ Form
 
 				RadioButton
 				{
-					text: 							qsTr("Extrapolated amounts")
+					text: 							qsTr("Monetary values")
 					name: 							"amount"
 					enabled:						values.count > 0
 				}

--- a/inst/qml/auditClassicalWorkflow.qml
+++ b/inst/qml/auditClassicalWorkflow.qml
@@ -663,7 +663,7 @@ Form
 
 			CheckBox
 			{
-				text: 								qsTr("Display sample")
+				text: 								qsTr("Selected items")
 				name: 								"tableSample"
 			}
 		}

--- a/inst/qml/auditClassicalWorkflow.qml
+++ b/inst/qml/auditClassicalWorkflow.qml
@@ -220,7 +220,7 @@ Form
 				singleVariable:						true
 				allowedColumns:						["nominal", "nominalText", "ordinal", "scale"]
 				allowAnalysisOwnComputedColumns: 	false
-				onCountChanged:						if(lik_hypergeometric.checked && id.count == 0) lik_poisson.click()
+				onCountChanged:						if(lik_hypergeometric.checked && id.count == 0) lik_binomial.click()
 			}
 
 			AssignedVariablesList

--- a/inst/qml/auditClassicalWorkflow.qml
+++ b/inst/qml/auditClassicalWorkflow.qml
@@ -523,14 +523,27 @@ Form
 				}
 			}
 
-			IntegerField
+			Group
 			{
-				name: 								"by"
-				text: 								qsTr("Increment")
-				min: 								1
-				max:								50
-				defaultValue: 						1
+				title:								qsTr("Iterations")
 				enabled:							!pasteVariables.checked
+
+				IntegerField
+				{
+					name: 							"by"
+					text: 							qsTr("Increment")
+					min: 							1
+					max:							50
+					defaultValue: 					1
+				}
+
+				IntegerField
+				{
+					name: 							"max"
+					text: 							qsTr("Maximum")
+					min: 							1
+					defaultValue: 					5000
+				}
 			}
 		}
 

--- a/inst/qml/auditClassicalWorkflow.qml
+++ b/inst/qml/auditClassicalWorkflow.qml
@@ -324,7 +324,7 @@ Form
 			id: 									expected
 			name: 									"expected_type"
 			title: 									qsTr("Expected Errors in Sample")
-			enabled:								ir.value == 'high' && cr.value == 'high' && !pasteVariables.checked
+			enabled:								!pasteVariables.checked
 
 			RadioButton
 			{
@@ -385,10 +385,10 @@ Form
 
 			RadioButton
 			{
-				id: 								lik_poisson
-				text: 								qsTr("Poisson")
-				name: 								"poisson"
-				checked: 							true
+				id: 								lik_hypergeometric
+				text: 								qsTr("Hypergeometric")
+				name: 								"hypergeometric"
+				enabled:							id.count > 0
 			}
 
 			RadioButton
@@ -396,14 +396,14 @@ Form
 				id: 								lik_binomial
 				text: 								qsTr("Binomial")
 				name: 								"binomial"
+				checked: 							true
 			}
 
 			RadioButton
 			{
-				id: 								lik_hypergeometric
-				text: 								qsTr("Hypergeometric")
-				name: 								"hypergeometric"
-				enabled:							id.count > 0
+				id: 								lik_poisson
+				text: 								qsTr("Poisson")
+				name: 								"poisson"
 			}
 		}
 
@@ -1025,10 +1025,10 @@ Form
 
 			RadioButton
 			{
-				id:									poisson
-				name: 								"poisson"
-				text: 								qsTr("Poisson")
-				checked:							true
+				id:									hypergeometric
+				name: 								"hypergeometric"
+				text: 								qsTr("Hypergeometric")
+				enabled:							id.count > 0
 			}
 
 			RadioButton
@@ -1036,14 +1036,14 @@ Form
 				id:									binomial
 				name: 								"binomial"
 				text: 								qsTr("Binomial")
+				checked:							true
 			}
 
 			RadioButton
 			{
-				id:									hypergeometric
-				name: 								"hypergeometric"
-				text: 								qsTr("Hypergeometric")
-				enabled:							id.count > 0
+				id:									poisson
+				name: 								"poisson"
+				text: 								qsTr("Poisson")
 			}
 
 			RadioButton

--- a/inst/qml/auditSelection.qml
+++ b/inst/qml/auditSelection.qml
@@ -183,7 +183,7 @@ Form
 
 		CheckBox
 		{
-			text: 								qsTr("Display sample")
+			text: 								qsTr("Selected items")
 			name: 								"tableSample"
 		}
 	}

--- a/inst/qml/auditSelection.qml
+++ b/inst/qml/auditSelection.qml
@@ -105,6 +105,14 @@ Form
 			max: 								99999
 			enabled:							randomize.checked || method.value != "interval"
 		}
+
+		CheckBox
+		{
+			id:									randomize
+			name:								"randomize"
+			text:								qsTr("Randomize item order")
+			enabled:							rank.count == 0
+		}
 	}
 
 	Group
@@ -175,7 +183,7 @@ Form
 
 		CheckBox
 		{
-			text: 								qsTr("Raw sample")
+			text: 								qsTr("Display sample")
 			name: 								"tableSample"
 		}
 	}
@@ -187,77 +195,57 @@ Form
 			id: 								method
 			title:								qsTr("Method")
 			name: 								"sampling_method"
+			columns:							2
 
-			Group
+			RadioButton
 			{
+				id: 							interval
+				text: 							qsTr("Fixed interval sampling")
+				name: 							"interval"
+				checked: 						true
 
-				Row
+				IntegerField
 				{
-					RadioButton
-					{
-						id: 					interval
-						text: 					qsTr("Fixed interval sampling")
-						name: 					"interval"
-						checked: 				true
-
-						IntegerField
-						{
-							id: 				start
-							text: 				qsTr("Starting point")
-							name: 				"start"
-							defaultValue: 		1
-							min: 				1
-							visible:			interval.checked
-						}
-					}
-
-					HelpButton
-					{
-						toolTip: 				qsTr("Click to learn more about fixed interval sampling.")
-						helpPage:				"Audit/fixedIntervalSampling"
-					}
-				}
-
-				Row
-				{
-					RadioButton
-					{
-						id: 					cell
-						text: 					qsTr("Cell sampling")
-						name: 					"cell"
-					}
-
-					HelpButton
-					{
-						toolTip: 				qsTr("Click to learn more about cell sampling.")
-						helpPage:				"Audit/cellSampling"
-					}
-				}
-
-				Row
-				{
-					RadioButton
-					{
-						id: 					random
-						text: 					qsTr("Random sampling")
-						name: 					"random"
-					}
-
-					HelpButton
-					{
-						toolTip: 				qsTr("Click to learn more about random sampling.")
-						helpPage:				"Audit/randomSampling"
-					}
+					id: 						start
+					text: 						qsTr("Starting point")
+					name: 						"start"
+					defaultValue: 				1
+					min: 						1
+					visible:					interval.checked
 				}
 			}
-		}
 
-		CheckBox
-		{
-			id:									randomize
-			name:								"randomize"
-			text:								qsTr("Randomize items")
-			enabled:							rank.count == 0
+			HelpButton
+			{
+				toolTip: 						qsTr("Click to learn more about fixed interval sampling.")
+				helpPage:						"Audit/fixedIntervalSampling"
+			}
+
+			RadioButton
+			{
+				id: 							cell
+				text: 							qsTr("Cell sampling")
+				name: 							"cell"
+			}
+
+			HelpButton
+			{
+				toolTip: 						qsTr("Click to learn more about cell sampling.")
+				helpPage:						"Audit/cellSampling"
+			}
+
+			RadioButton
+			{
+				id: 							random
+				text: 							qsTr("Random sampling")
+				name: 							"random"
+			}
+
+			HelpButton
+			{
+				toolTip: 						qsTr("Click to learn more about random sampling.")
+				helpPage:						"Audit/randomSampling"
+			}
 		}
 	}
 

--- a/tests/testthat/test-auditselection.R
+++ b/tests/testthat/test-auditselection.R
@@ -28,7 +28,7 @@ test_that("<b>Table 2.</b> Information about Monetary Interval Selection results
   )
 })
 
-test_that("<b>Table 3.</b> Raw Sample results match", {
+test_that("<b>Table 3.</b> Selected Items results match", {
   table <- results[["results"]][["selectionContainer"]][["collection"]][["selectionContainer_tableSample"]][["data"]]
   jaspTools::expect_equal_tables(
     table,
@@ -136,7 +136,7 @@ set.seed(1)
 results <- jaspTools::runAnalysis("auditSelection", "BuildIt_Monetary.csv", options)
 
 
-test_that("<b>Table 2.</b> Raw Sample results match", {
+test_that("<b>Table 2.</b> Selected Items results match", {
   table <- results[["results"]][["selectionContainer"]][["collection"]][["selectionContainer_tableSample"]][["data"]]
   jaspTools::expect_equal_tables(
     table,
@@ -254,7 +254,7 @@ test_that("<b>Table 2.</b> Descriptive Statistics for Sample results match", {
   )
 })
 
-test_that("<b>Table 3.</b> Raw Sample results match", {
+test_that("<b>Table 3.</b> Selected Items results match", {
   table <- results[["results"]][["selectionContainer"]][["collection"]][["selectionContainer_tableSample"]][["data"]]
   jaspTools::expect_equal_tables(
     table,

--- a/tests/testthat/test-uvb.R
+++ b/tests/testthat/test-uvb.R
@@ -79,7 +79,7 @@ test_that("<b>Table 3.</b> Information about Monetary Interval Selection results
   )
 })
 
-test_that("<b>Table 4.</b> Raw Sample results match", {
+test_that("<b>Table 4.</b> Selected Items results match", {
   table <- results[["results"]][["selectionContainer"]][["collection"]][["selectionContainer_tableSample"]][["data"]]
   jaspTools::expect_equal_tables(
     table,


### PR DESCRIPTION
- Fixes an issue where the record Id variable was not identified as unique
- Fixes an issue with the explanatory text where errors = all possible in planning text was not shown correctly.
- Fixes an issue where the starting point would differ after refreshing the analysis.
- jfa 0.6.2 fixes an issue with the computation speed by not computing the prior predictive by default.
  - Replicate: Planning -> Probability Distribution (beta) -> Large number of N.units (e.g., 60000000)
- Implement feedback that an option was desired to indicate the maximum allowed sample size.
- Implemented feedback which asked for more elaborate explanation of the probability distribution (via the "i" icon)