### PR TITLE
Bug fix for sample size

### DIFF
--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -3350,7 +3350,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
 .jfaSeparatedMisstatementPlanningState <- function(options, dataset, prior, parentOptions) {
 
   # Plan a sample for the efficiency technique Separate known and unknown misstatement
-  for (n in seq(5, nrow(dataset), by = options[["by"]])) {
+  for (n in seq(5, options[["max"]], by = options[["by"]])) {
     interval <- (parentOptions[["N.units"]] / n)
     topStratum <- subset(dataset, dataset[[options[["values"]]]] > interval)
     bottomStratum <- subset(dataset, dataset[[options[["values"]]]] <= interval)


### PR DESCRIPTION
In bayesian workflow -> assume homogeneous taints --> all possible errors -> increment = 5, the sample size stopped at the number of items instread of the option maximum. The result is a sample size of 15 (wrong) instead of 25 (right).

Data file: [2019EFA2018 CSV.csv](https://github.com/jasp-stats/jaspAudit/files/7868579/2019EFA2018.CSV.csv)
JASP file (remove .zip): [samplesizemistake.zip](https://github.com/jasp-stats/jaspAudit/files/7868594/samplesizemistake.zip)
 