### PR TITLE
Fix space between checkboxes in bayesian planning

### DIFF
--- a/R/auditCommonFunctionsBayesian.R
+++ b/R/auditCommonFunctionsBayesian.R
@@ -73,7 +73,7 @@
     title <- if (stage == "planning") gettext("Prior and Expected Posterior Distribution") else gettext("Prior and Posterior Distribution")
     figure <- createJaspPlot(plot = NULL, title = title, width = 530, height = 350)
     figure$position <- positionInContainer
-    depends <- if (stage == "planning") c("plotPrior", "plotPriorInfo") else c("plotPosterior", "plotPosteriorInfo", "area")
+    depends <- if (stage == "planning") "plotPrior" else c("plotPosterior", "plotPosteriorInfo", "area")
     figure$dependOn(options = depends)
 
     parentContainer[["plotPriorAndPosterior"]] <- figure
@@ -83,7 +83,7 @@
     }
 
     method <- if (stage == "planning") options[["likelihood"]] else options[["method"]]
-    info <- if (stage == "planning") options[["plotPriorInfo"]] else options[["plotPosteriorInfo"]]
+    info <- if (stage == "planning") FALSE else options[["plotPosteriorInfo"]]
 
     if (method != "hypergeometric") { # Gamma and beta priors
 
@@ -138,7 +138,6 @@
         ggplot2::scale_fill_manual(values = c("lightgray", "darkgray"), breaks = c(gettext("Prior"), gettext("Posterior"))) +
         ggplot2::labs(fill = "")
     }
-
 
     plot <- plot + jaspGraphs::geom_rangeframe() +
       jaspGraphs::themeJaspRaw(legend.position = c(0.8, 0.875)) +

--- a/inst/qml/auditBayesianPlanning.qml
+++ b/inst/qml/auditBayesianPlanning.qml
@@ -301,12 +301,6 @@ Form
 			{
 				text: 							qsTr("Prior and posterior")
 				name: 							"plotPrior"
-
-				CheckBox
-				{
-					name: 						"plotPriorInfo"
-					visible:					false
-				}
 			}
 
 			CheckBox

--- a/inst/qml/auditBayesianWorkflow.qml
+++ b/inst/qml/auditBayesianWorkflow.qml
@@ -369,12 +369,6 @@ Form
 				{
 					text: 							qsTr("Prior and posterior")
 					name: 							"plotPrior"
-
-					CheckBox
-					{
-						name: 						"plotPriorInfo"
-						visible:					false
-					}
 				}
 
 				CheckBox


### PR DESCRIPTION
Without fix (notice the space between the second and third checkbox because of the invisible checkbox that is not there in the second image): 
![image](https://user-images.githubusercontent.com/25059399/166205810-d7b834ff-00f4-4c94-94a7-82ca9eade457.png)


With fix:
![image](https://user-images.githubusercontent.com/25059399/166205784-3f5d089f-f49e-484c-a7dd-603efbe9cecb.png)

The option that is removed was is not used in the planning stage anymore (it is hard coded to FALSE now)