### PR TITLE
Translate default custom column names + add taint table + take number of items and units from population if requested

### DIFF
--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -577,7 +577,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
   }
 }
 
-.jfaInputOptionsGather <- function(options, dataset, jaspResults, stage, rawData = FALSE, rawDataset = NULL) {
+.jfaInputOptionsGather <- function(options, dataset, jaspResults, stage, rawData = FALSE) {
   input <- list()
 
   if (stage == "planning") {

--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -1650,7 +1650,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
   if (!options[["bayesian"]]) {
     message <- switch(options[["likelihood"]],
       "poisson" = gettextf("The minimum sample size is based on the Poisson distribution (%1$s = %2$s).", "\u03BB", round(parentState[["materiality"]] * parentState[["n"]], 4)),
-      "binomial" =  gettextf("The minimum sample size is based on the binomial distribution (p = %1$s)", round(parentState[["materiality"]], 2)),
+      "binomial" =  gettextf("The minimum sample size is based on the binomial distribution (p = %1$s)", round(parentState[["materiality"]], 4)),
       "hypergeometric" = gettextf("The minimum sample size is based on the hypergeometric distribution (N = %1$s, K = %2$s).", format(parentState[["N.units"]], scientific = FALSE), format(ceiling(parentState[["N.units"]] * parentState[["materiality"]]), scientific = FALSE))
     )
   } else {

--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -841,12 +841,12 @@ gettextf <- function(fmt, ..., domain = NULL) {
       return(FALSE)
     }
   } else if (stage == "evaluation") {
-    if (!options[["bayesian"]] && options[["method"]] == "hypergeometric" && options[["n_units"]] == 0) {
+    if (!options[["bayesian"]] && options[["method"]] == "hypergeometric" && (options[["n_units"]] == 0 && options[["dataType"]] != "pdata")) {
       # Error if the population size is not defined when the hypergeometric bound is used.
       parentContainer[["errorMessage"]] <- createJaspTable(gettext("Evaluation Summary"))
       parentContainer$setError(gettext("The hypergeometric upper bound requires that you specify the number of units in the population."))
       return(TRUE)
-    } else if (options[["method"]] %in% c("direct", "difference", "quotient", "regression") && (options[["n_items"]] == 0 || options[["n_units"]] == 0)) {
+    } else if (options[["method"]] %in% c("direct", "difference", "quotient", "regression") && ((options[["n_items"]] == 0 || options[["n_units"]] == 0) && options[["dataType"]] != "pdata")) {
       # Error if the population size or the population value are zero when using direct, difference, quotient, or regression.
       parentContainer[["errorMessage"]] <- createJaspTable(gettext("Evaluation Summary"))
       parentContainer$setError(gettext("The direct, difference, ratio, and regression bounds require that you specify the number of items and the number of units in the population."))

--- a/R/auditCommonFunctionsBayesian.R
+++ b/R/auditCommonFunctionsBayesian.R
@@ -328,7 +328,7 @@
       }
     } else if (stage == "evaluation") {
       if (!(options[["materiality_test"]] || options[["min_precision_test"]]) ||
-        ((options[["values.audit"]] == "" || options[["id"]] == "") && options[["dataType"]] == "data") ||
+        ((options[["values.audit"]] == "" || options[["id"]] == "") && options[["dataType"]] %in% c("data", "pdata")) ||
         (options[["dataType"]] == "stats" && options[["n"]] == 0) ||
         (parentOptions[["materiality_val"]] == 0 && options[["materiality_test"]]) ||
         parentContainer$getError()) {

--- a/inst/qml/auditBayesianEvaluation.qml
+++ b/inst/qml/auditBayesianEvaluation.qml
@@ -175,6 +175,7 @@ Form
 				defaultValue: 					0
 				fieldWidth: 					100 * preferencesModel.uiScale
 				min: 							0
+				enabled:						!pdata.checked
 			}
 
 			DoubleField
@@ -186,6 +187,7 @@ Form
 				fieldWidth: 					100 * preferencesModel.uiScale
 				min: 							0
 				decimals: 						2
+				enabled:						!pdata.checked
 			}
 		}
 
@@ -254,10 +256,18 @@ Form
 
 		RadioButton
 		{
+			id: 								pdata
+			name: 								"pdata"
+			label:								qsTr("Population")
+			checked: 							mainWindow.dataAvailable
+			enabled:							mainWindow.dataAvailable
+		}
+
+		RadioButton
+		{
 			id: 								data
 			name: 								"data"
-			label:								qsTr("Columns")
-			checked: 							mainWindow.dataAvailable
+			label:								qsTr("Sample")
 			enabled:							mainWindow.dataAvailable
 		}
 
@@ -325,7 +335,7 @@ Form
 			id:									hypergeometric
 			name: 								"hypergeometric"
 			text: 								qsTr("Beta-binomial")
-			enabled: 							n_units.value > 0
+			enabled: 							n_units.value > 0 || pdata.checked
 		}
 
 		RadioButton
@@ -358,14 +368,14 @@ Form
 		{
 			text: 								qsTr("Misstated items")
 			name: 								"tableTaints"
-			enabled:							values.count > 0 && data.checked
+			enabled:							values.count > 0 && !stats.checked
 		}
 
 		CheckBox
 		{
 			text: 								qsTr("Corrections to population")
 			name: 								"tableCorrections"
-			enabled:							n_units.value > 0
+			enabled:							n_units.value > 0 || pdata.checked
 		}
 
 		CheckBox
@@ -695,7 +705,7 @@ Form
 			{
 				text: 							qsTr("Monetary values")
 				name: 							"amount"
-				enabled:						n_units.value > 0
+				enabled:						n_units.value > 0 || pdata.checked
 			}
 		}
 
@@ -710,7 +720,7 @@ Form
 					id: 						separate
 					text: 						qsTr("Assume homogeneous taints")
 					name: 						"separateMisstatement"
-					enabled:					id.count > 0 && values.count > 0 && auditResult.count > 0 && n_items.value > 0 && n_units.value > 0 && binomial.checked
+					enabled:					id.count > 0 && values.count > 0 && auditResult.count > 0 && ((n_items.value > 0 && n_units.value > 0) || pdata.checked) && binomial.checked
 				}
 
 				HelpButton

--- a/inst/qml/auditBayesianEvaluation.qml
+++ b/inst/qml/auditBayesianEvaluation.qml
@@ -356,6 +356,13 @@ Form
 
 		CheckBox
 		{
+			text: 								qsTr("Misstated items")
+			name: 								"tableTaints"
+			enabled:							values.count > 0 && data.checked
+		}
+
+		CheckBox
+		{
 			text: 								qsTr("Corrections to population")
 			name: 								"tableCorrections"
 			enabled:							n_units.value > 0

--- a/inst/qml/auditBayesianWorkflow.qml
+++ b/inst/qml/auditBayesianWorkflow.qml
@@ -551,7 +551,7 @@ Form
 						name: 						"critical_name"
 						text: 						qsTr("Column name")
 						fieldWidth: 				120 * preferencesModel.uiScale
-						value: 						"critical"
+						value: 						qsTr("critical")
 					}
 
 					RadioButtonGroup
@@ -985,7 +985,7 @@ Form
 				name: 								"indicator_col"
 				text: 								qsTr("Column name selection result")
 				fieldWidth: 						120 * preferencesModel.uiScale
-				value:								"selected"
+				value:								qsTr("selected")
 			}
 
 			ComputedColumnField
@@ -994,7 +994,7 @@ Form
 				name: 								"variable_col"
 				text: 								qsTr("Column name audit result")
 				fieldWidth: 						120 * preferencesModel.uiScale
-				value: 								"auditResult"
+				value: 								qsTr("auditResult")
 			}
 		}
 

--- a/inst/qml/auditBayesianWorkflow.qml
+++ b/inst/qml/auditBayesianWorkflow.qml
@@ -1177,6 +1177,13 @@ Form
 
 			CheckBox
 			{
+				text: 								qsTr("Misstated items")
+				name: 								"tableTaints"
+				enabled:							values.count > 0 && data.checked
+			}
+
+			CheckBox
+			{
 				text: 								qsTr("Corrections to population")
 				name: 								"tableCorrections"
 				enabled:							values.count > 0

--- a/inst/qml/auditClassicalEvaluation.qml
+++ b/inst/qml/auditClassicalEvaluation.qml
@@ -409,7 +409,7 @@ Form
 		{
 			text: 						qsTr("Corrections to population")
 			name: 						"tableCorrections"
-			enabled:					n_units.value > 0
+			enabled:					n_units.value != 0 || pdata.checked
 		}
 	}
 
@@ -422,7 +422,7 @@ Form
 		{
 			name: 							"hypergeometric"
 			text: 							qsTr("Hypergeometric")
-			enabled:						n_units.value > 0
+			enabled:						n_units.value != 0 || pdata.checked
 		}
 
 		RadioButton
@@ -485,7 +485,7 @@ Form
 		{
 			name: 							"regression"
 			text: 							qsTr("Regression estimator")
-			enabled: 						!stats.checked && n_units.value != 0 && n_items.value != 0 && values.count > 0 && auditResult.count > 0
+			enabled: 						!stats.checked && ((n_units.value != 0 && n_items.value != 0) || pdata.checked) && values.count > 0 && auditResult.count > 0
 		}
 	}
 

--- a/inst/qml/auditClassicalEvaluation.qml
+++ b/inst/qml/auditClassicalEvaluation.qml
@@ -390,6 +390,13 @@ Form
 
 		CheckBox
 		{
+			text: 						qsTr("Misstated items")
+			name: 						"tableTaints"
+			enabled:					values.count > 0 && data.checked
+		}
+
+		CheckBox
+		{
 			text: 						qsTr("Corrections to population")
 			name: 						"tableCorrections"
 			enabled:					n_units.value > 0

--- a/inst/qml/auditClassicalEvaluation.qml
+++ b/inst/qml/auditClassicalEvaluation.qml
@@ -187,6 +187,7 @@ Form
 				defaultValue: 					0
 				fieldWidth: 					100 * preferencesModel.uiScale
 				min: 							0
+				enabled:						!pdata.checked
 			}
 
 			DoubleField
@@ -198,6 +199,7 @@ Form
 				fieldWidth: 					100 * preferencesModel.uiScale
 				min: 							0
 				decimals: 						2
+				enabled:						!pdata.checked				
 			}
 		}
 
@@ -266,10 +268,18 @@ Form
 
 		RadioButton
 		{
+			id: 								pdata
+			name: 								"pdata"
+			label:								qsTr("Population")
+			checked: 							mainWindow.dataAvailable
+			enabled:							mainWindow.dataAvailable
+		}
+
+		RadioButton
+		{
 			id: 								data
 			name: 								"data"
-			label:								qsTr("Columns")
-			checked: 							mainWindow.dataAvailable
+			label:								qsTr("Sample")
 			enabled:							mainWindow.dataAvailable
 		}
 
@@ -392,7 +402,7 @@ Form
 		{
 			text: 						qsTr("Misstated items")
 			name: 						"tableTaints"
-			enabled:					values.count > 0 && data.checked
+			enabled:					values.count > 0 && !stats.checked
 		}
 
 		CheckBox
@@ -454,21 +464,21 @@ Form
 		{
 			name: 							"direct"
 			text: 							qsTr("Direct estimator")
-			enabled: 						!stats.checked && n_units.value != 0 && n_items.value != 0 && values.count > 0 && auditResult.count > 0
+			enabled: 						!stats.checked && ((n_units.value != 0 && n_items.value != 0) || pdata.checked) && values.count > 0 && auditResult.count > 0
 		}
 
 		RadioButton
 		{
 			name: 							"difference"
 			text: 							qsTr("Difference estimator")
-			enabled: 						!stats.checked && n_units.value != 0 && n_items.value != 0 && values.count > 0 && auditResult.count > 0
+			enabled: 						!stats.checked && ((n_units.value != 0 && n_items.value != 0) || pdata.checked) && values.count > 0 && auditResult.count > 0
 		}
 
 		RadioButton
 		{
 			name: 							"quotient"
 			text: 							qsTr("Ratio estimator")
-			enabled: 						!stats.checked && n_units.value != 0 && n_items.value != 0 && values.count > 0 && auditResult.count > 0
+			enabled: 						!stats.checked && ((n_units.value != 0 && n_items.value != 0) || pdata.checked) && values.count > 0 && auditResult.count > 0
 		}
 
 		RadioButton
@@ -570,7 +580,7 @@ Form
 			{
 				text: 							qsTr("Monetary values")
 				name: 							"amount"
-				enabled:						n_units.value != 0
+				enabled:						n_units.value != 0 || pdata.checked
 			}
 		}
 	}

--- a/inst/qml/auditClassicalWorkflow.qml
+++ b/inst/qml/auditClassicalWorkflow.qml
@@ -457,7 +457,7 @@ Form
 						name: 						"critical_name"
 						text: 						qsTr("Column name")
 						fieldWidth: 				120 * preferencesModel.uiScale
-						value: 						"critical"
+						value: 						qsTr("critical")
 					}
 
 					RadioButtonGroup
@@ -861,7 +861,7 @@ Form
 				name: 								"indicator_col"
 				text: 								qsTr("Column name selection result")
 				fieldWidth: 						120 * preferencesModel.uiScale
-				value:								"selected"
+				value:								qsTr("selected")
 			}
 
 			ComputedColumnField
@@ -870,7 +870,7 @@ Form
 				name: 								"variable_col"
 				text: 								qsTr("Column name audit result")
 				fieldWidth: 						120 * preferencesModel.uiScale
-				value: 								"auditResult"
+				value: 								qsTr("auditResult")
 			}
 		}
 

--- a/inst/qml/auditClassicalWorkflow.qml
+++ b/inst/qml/auditClassicalWorkflow.qml
@@ -1112,6 +1112,13 @@ Form
 
 				CheckBox
 				{
+					text: 							qsTr("Misstated items")
+					name: 							"tableTaints"
+					enabled:						values.count > 0 && data.checked
+				}
+
+				CheckBox
+				{
 					text: 							qsTr("Corrections to population")
 					name: 							"tableCorrections"
 					enabled:						values.count > 0


### PR DESCRIPTION
- Column names for custom columns in the audit worksflow(s) were not translated.
- There is a new table added in the evaluation showing the misstated items and their taints
![image](https://user-images.githubusercontent.com/25059399/174261940-5f017622-0716-42e6-bf76-1aa9ce4bb700.png)
- You can now take the population number of items and number of units from the data instead of manually filling them in.