### PR TITLE
Remove min.precision from evaluation

### DIFF
--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -2505,7 +2505,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
       }
       result <- try({
         jfa::evaluation(
-          conf.level = conf_level, materiality = materiality, min.precision = min_precision,
+          conf.level = conf_level, materiality = materiality,
           n = nrow(sample), x = length(which(sample[[options[["values.audit"]]]] == 1)),
           method = options[["method"]], N.units = prevOptions[["N.units"]],
           prior = prior
@@ -2520,7 +2520,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
       result <- try({
         jfa::evaluation(
           data = sample, times = options[["indicator_col"]], conf.level = conf_level,
-          materiality = materiality, min.precision = min_precision, alternative = if (options[["method"]] %in% c("direct", "difference", "quotient", "regression")) "two.sided" else "less",
+          materiality = materiality, alternative = if (options[["method"]] %in% c("direct", "difference", "quotient", "regression")) "two.sided" else "less",
           values = options[["values"]], values.audit = options[["values.audit"]],
           method = method, N.items = prevOptions[["N.items"]], N.units = prevOptions[["N.units"]],
           prior = prior
@@ -2733,7 +2733,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
     if (options[["dataType"]] == "stats") {
       result <- try({
         jfa::evaluation(
-          conf.level = conf_level, materiality = materiality, min.precision = min_precision,
+          conf.level = conf_level, materiality = materiality,
           n = options[["n"]], x = options[["x"]], method = options[["method"]],
           N.units = planningOptions[["N.units"]], prior = prior
         )
@@ -2741,7 +2741,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
     } else if (all(unique(sample[[options[["values.audit"]]]]) %in% c(0, 1))) {
       result <- try({
         jfa::evaluation(
-          conf.level = conf_level, materiality = materiality, min.precision = min_precision,
+          conf.level = conf_level, materiality = materiality,
           n = nrow(sample), x = length(which(sample[[options[["values.audit"]]]] == 1)),
           method = options[["method"]], N.units = planningOptions[["N.units"]],
           prior = prior


### PR DESCRIPTION
I am intending to remove the `min.precision` argument from the `evaluation()` function in the `jfa` package. That means that the audit module, in its current form, will complain about `unused argument (min.precision = ....)`. In the dev version of `jfa`, this is solved by including `...` in the function arguments (see [here](https://github.com/koenderks/jfa/blob/6b5376d5844b1440bcc4b6ea6a9b7c18a039c186/R/evaluation.R#L115-L116)), but ideally this would not be neccesary. The `min.precision` argument did nothing of importance in the function, hence it can be safely removed here as well.