### PR TITLE
Remove leftover min.precision

### DIFF
--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -2760,7 +2760,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
         result <- try({
           jfa::evaluation(
             data = sample, times = if (options[["times"]] != "") options[["times"]] else NULL, conf.level = conf_level, materiality = materiality,
-            min.precision = min_precision, values = options[["values"]], values.audit = options[["values.audit"]], alternative = if (options[["method"]] %in% c("direct", "difference", "quotient", "regression")) "two.sided" else "less",
+            values = options[["values"]], values.audit = options[["values.audit"]], alternative = if (options[["method"]] %in% c("direct", "difference", "quotient", "regression")) "two.sided" else "less",
             method = method, N.items = planningOptions[["N.items"]], N.units = planningOptions[["N.units"]],
             prior = prior
           )


### PR DESCRIPTION
The unit tests seem to fail since I removed the `min.precision` argument in the `evaluation()` function, since I forgot to remove one of them in the common `R` file.

Closes https://github.com/jasp-stats/jaspAudit/issues/280