### PR TITLE
Use jfa 0.6.7 for release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,10 +16,9 @@ Imports:
   ggrepel,
   jaspBase,
   jaspGraphs,
-  jfa (== 0.6.7),
+  jfa (>= 0.6.7),
   utils
 Remotes:
   jasp-stats/jaspBase,
   jasp-stats/jaspGraphs,
-  alexanderlynl/bstats,
-  koenderks/jfa
+  alexanderlynl/bstats

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Imports:
   ggrepel,
   jaspBase,
   jaspGraphs,
-  jfa (>= 0.6.7),
+  jfa (== 0.6.7),
   utils
 Remotes:
   jasp-stats/jaspBase,


### PR DESCRIPTION
In the development version of jfa (i.e., 0.7.0 on GitHub) there are some changes to the option names that will break the current functionality in JASP, hence this PR for the upcoming release.