### PR TITLE
Fix crash for absolute materiality value with stratification

### DIFF
--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -649,7 +649,7 @@ gettextf <- function(fmt, ..., domain = NULL) {
       input[["N.units"]] <- options[["n_units"]]
     }
 
-    input[["materiality_val"]] <- if (options[["materiality_type"]] == "materiality_rel") options[["materiality_rel_val"]] else options[["materiality_abs_val"]] / input[["N.units"]]
+    input[["materiality_val"]] <- if (options[["materiality_type"]] == "materiality_rel") options[["materiality_rel_val"]] else options[["materiality_abs_val"]] / sum(input[["N.units"]])
     input[["materiality_label"]] <- if (options[["materiality_type"]] == "materiality_rel") paste0(round(options[["materiality_rel_val"]] * 100, 2), "%") else format(options[["materiality_abs_val"]], scientific = FALSE)
 
     if (options[["bayesian"]]) {


### PR DESCRIPTION
Fix the bug in this JASP file:
[error.jasp.zip](https://github.com/jasp-stats/jaspAudit/files/15203165/error.jasp.zip)

<img width="1512" alt="image" src="https://github.com/jasp-stats/jaspAudit/assets/25059399/4bd14613-8e6b-449c-ab84-d8fe099d90bb">
